### PR TITLE
Configure GRUB settings based on spice level

### DIFF
--- a/roles/sngfd_factory_12/templates/sng_late_command.j2
+++ b/roles/sngfd_factory_12/templates/sng_late_command.j2
@@ -230,7 +230,7 @@ EOFGD
 # serial port extras for GRUB
 cat /proc/cmdline
 gotserial=$(grep -m 1 "console=tty0 console=ttyS0" /proc/cmdline | wc -l)
-if [ "$gotserial" -eq 1 ]; then
+if [ "$gotserial" -eq 1 ] || [ "$spicelevel" == "int" ]; then
 	cat << EOFGS > /target/etc/default/grub.d/20-sangoma.cfg
 GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX} console=tty0 console=ttyS0,115200n8"
 GRUB_SERIAL_COMMAND="serial --unit=0 --speed=115200"


### PR DESCRIPTION
- Added conditional logic to set GRUB configuration in /target/etc/default/grub.d/10-sangoma.cfg based on the spice level.
- For 'int' spice level:
  - Configured console output for serial and graphical terminal.
  - Set GRUB_CMDLINE_LINUX to include console parameters.
- For other spice levels:
  - Kept GRUB_CMDLINE_LINUX empty.
- Maintained other GRUB settings such as timeout, distributor name, and graphics mode.