### PR TITLE
INTernal spice default drive selection is small.

### DIFF
--- a/roles/sngfd_factory_12/templates/sng_preseed_chooser_command.j2
+++ b/roles/sngfd_factory_12/templates/sng_preseed_chooser_command.j2
@@ -50,10 +50,10 @@ if $raid; then
 	if [ "$spicelevel" = "int" ]; then
 		disk_part=$(list-devices disk | grep -e 'da$' | cut -f3 -d/)
                 disk_size=$(awk '{print $1 * 512/ 1024/ 1024/ 1024 }' /sys/block/${disk_part}/size)
-                result=$(eval "awk 'BEGIN {
-               		 if ($disk_size <= 250) print 1;
-                	 else if ($disk_size > 250 && $disk_size <= 500) print 2;
-                	 else print 3;
+		result=$(eval "awk 'BEGIN {
+			if ($disk_size > 900) print 3;
+			else if ($disk_size > 450) print 2;
+			else print 1;
                		 }'")
            	if [ "$result" -eq 1 ]; then
                 	echo "preseed_partman_recipe_raid_${spicelevel}_250.cfg"
@@ -85,10 +85,10 @@ else
         if [ "$spicelevel" = "int" ]; then
                 disk_part=$(list-devices disk | grep -e 'da$' | cut -f3 -d/)
                 disk_size=$(awk '{print $1 * 512/ 1024/ 1024/ 1024 }' /sys/block/${disk_part}/size)
-		        result=$(eval "awk 'BEGIN {
-          		       if ($disk_size <= 120) print 1;
-                	       else print 2;
-                	       }'")
+		result=$(eval "awk 'BEGIN {
+			if ($disk_size > 240) print 2;
+			else print 1;
+			}'")
         	if [ "$result" -eq 1 ]; then
                 	echo "preseed_partman_recipe_nonraid_${spicelevel}_120.cfg"
                 	logger -t sng "CHOSE preseed_partman_recipe_nonraid_${spicelevel}_120.cfg"

--- a/roles/sngfd_factory_12/templates/sng_preseed_chooser_command.j2
+++ b/roles/sngfd_factory_12/templates/sng_preseed_chooser_command.j2
@@ -50,12 +50,12 @@ if $raid; then
 	if [ "$spicelevel" = "int" ]; then
 		disk_part=$(list-devices disk | grep -e 'da$' | cut -f3 -d/)
                 disk_size=$(awk '{print $1 * 512/ 1024/ 1024/ 1024 }' /sys/block/${disk_part}/size)
-		result=$(eval "awk 'BEGIN {
-			if ($disk_size > 900) print 3;
-			else if ($disk_size > 450) print 2;
-			else print 1;
+                result=$(eval "awk 'BEGIN {
+               		 if ($disk_size <= 250) print 1;
+                	 else if ($disk_size > 250 && $disk_size <= 500) print 2;
+                	 else print 3;
                		 }'")
-           	if [ "$result" -eq 1 ]; then
+           	if [ "$result" -eq 1 ] || [ "$disk_part" = "" ]; then
                 	echo "preseed_partman_recipe_raid_${spicelevel}_250.cfg"
                 	logger -t sng "CHOSE preseed_partman_recipe_raid_${spicelevel}_250.cfg"
         	elif [ "$result" -eq 2 ]; then
@@ -85,11 +85,11 @@ else
         if [ "$spicelevel" = "int" ]; then
                 disk_part=$(list-devices disk | grep -e 'da$' | cut -f3 -d/)
                 disk_size=$(awk '{print $1 * 512/ 1024/ 1024/ 1024 }' /sys/block/${disk_part}/size)
-		result=$(eval "awk 'BEGIN {
-			if ($disk_size > 240) print 2;
-			else print 1;
-			}'")
-        	if [ "$result" -eq 1 ]; then
+		        result=$(eval "awk 'BEGIN {
+          		       if ($disk_size <= 120) print 1;
+                	       else print 2;
+                	       }'")
+        	if [ "$result" -eq 1 ] || [ "$disk_part" = "" ]; then
                 	echo "preseed_partman_recipe_nonraid_${spicelevel}_120.cfg"
                 	logger -t sng "CHOSE preseed_partman_recipe_nonraid_${spicelevel}_120.cfg"
         	else


### PR DESCRIPTION
NVMe drives are not yet detected when preseed chooser is running. This makes drive space calculation challenging.
Patch helps the chooser make better choices for space allocation.

Fixes: #9