### PR TITLE
Restore PXE tarball and fix ISO version naming.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.iso
+*.gz
+*.tar
+*-RUN-ON-PXE-COBBLER-*

--- a/abuild-fpbx-installer-iso
+++ b/abuild-fpbx-installer-iso
@@ -9,9 +9,15 @@
 
 usage() {
 	echo "
-Usage: $0 -i debian_input.iso
+Minimal Usage: $0 -i debian_input.iso
 
-Example: $0 -i /path/to/debian-12.8.0-amd64-netinst.iso
+Options:
+	-i	Path to input ISO file.
+	-p	Path to mini input ISO for network installs with PXE and Cobbler.
+
+Examples:
+	$0 -i /path/to/debian-12.8.0-amd64-netinst.iso
+	$0 -i /path/to/debian-12.8.0-amd64-netinst.iso -p /path/to/mini-debian.iso
 
 You can change more options by setting Ansible variables on a per host or group basis.
 This shell script is a simple wrapper around ansible-playbook to run on your localhost.
@@ -20,10 +26,13 @@ Please see README.md for more information.
 	exit 1
 }
 
-while getopts ":i:" opt; do
+while getopts ":i:p:" opt; do
 	case "${opt}" in
 		i)
 			fn_iso_input=${OPTARG}
+			;;
+		p)
+			fn_mini_iso_input=${OPTARG}
 			;;
 		*)
 			usage
@@ -39,6 +48,6 @@ fi
 ansible-playbook \
 	--inventory localhost, \
 	--connection=local \
-	--extra-vars "fn_iso_input=${fn_iso_input}" \
+	--extra-vars "fn_iso_input=${fn_iso_input} fn_mini_iso_input=${fn_mini_iso_input}" \
 	default-playbook.yml
 

--- a/roles/sngfd_factory_12/defaults/main/defaults.yml
+++ b/roles/sngfd_factory_12/defaults/main/defaults.yml
@@ -14,27 +14,34 @@ str_freepbx_version: "17"
 str_vendor: "Sangoma"
 str_vendor_url: "https://www.sangoma.com/"
 str_our_full_name: "Sangoma FreePBX Distro"
-str_our_short_cap_name: "SNGFD"
+str_our_short_cap_name: "SNGDEB"
 
 # Support Debian 12 bookworm
 str_deb_codename: "bookworm"
 str_deb_version: "12"
 
-# Script versioning
-str_script_minor: "1.3-BETA"
-str_script_build: "2025-02-21.1"
+# Script versioning - CHANGE THESE TWO WHEN MAKING A NEW ISO
+str_script_minor: "10.0"
+str_script_bump: "2"
+
+# Architecture
+str_arch: "amd64"
 
 # Computed values
+str_script_build: "{{ '%y%m' | strftime }}.{{ str_script_bump }}"
 str_script_codename: "{{ str_deb_codename }}"
 str_script_major: "{{ str_deb_version }}"
-str_script_version: "{{ str_script_major }}.{{ str_script_minor }}"
+str_script_version: "{{ str_script_major }}.{{ str_script_minor }}.{{ str_script_build }}"
 str_script_version_underscore: "{{ str_script_version | regex_replace('\\.|-', '_') }}"
 str_script_version_hyphen: "{{ str_script_version | regex_replace('\\.', '-') }}"
 str_script_name: "sngfd_factory_12"
 str_script_sha512sum: "TBD"
 
 # Computed first part of the name of the output iso file
-str_iso_out_base: "{{ str_our_short_cap_name }}-{{ str_script_version_hyphen }}"
+str_iso_out_base: "{{ str_our_short_cap_name }}-PBX{{ str_freepbx_version }}-{{ str_arch|lower }}-{{ str_script_version_hyphen }}"
+
+# Cobbler does not like the arch name. :-/
+str_cob_base: "{{ str_our_short_cap_name }}-PBX{{ str_freepbx_version }}-{{ str_script_version_hyphen }}"
 
 # Now some variables that might get overwritten by command line options...
 
@@ -123,6 +130,7 @@ int_lvm_guided_size: 50
 # Minimum: 1
 int_mb_ssd_wear: 10240
 
+# These minimums only affect INT spice level.
 root_partition_size_120GB: 24576 
 root_partition_size_250GB: 51200
 root_partition_size_500GB: 102400
@@ -192,6 +200,7 @@ fn_netboot_initrd: ""
 
 # Must be supplied on command line
 #fn_iso_input: "debian-12.8.0-amd64-netinst.iso"
+#fn_mini_iso_input: "debian-12.8.0-amd64-mini.iso"
 
 # Used to depend on DIY and SPICE... back in the legacy shell days...
 fn_iso_output: "{{ str_iso_out_base }}.iso"
@@ -202,5 +211,7 @@ cpeid: "cpe:2.3:o:{{ str_vendor }}:{{ str_our_short_cap_name }}:{{ str_freepbx_v
 # New items only in the ansible version...
 
 # CDROM directory name.
-dn_cdrom: "cdrom-{{ str_our_short_cap_name|lower }}-{{ str_script_version_hyphen|lower }}"
+dn_cdrom: "cdrom-{{ str_iso_out_base|lower }}"
 
+# MINI ISO directory name.
+dn_mini: "mini-{{ str_iso_out_base|lower }}"

--- a/roles/sngfd_factory_12/tasks/directories.yml
+++ b/roles/sngfd_factory_12/tasks/directories.yml
@@ -27,3 +27,9 @@
     path: "{{ dtmp.path }}/extract"
     state: directory
   register: dextract
+
+- name: Prepare temporary mini ISO extraction directory.
+  ansible.builtin.file:
+    path: "{{ dextract.path }}/{{ dn_mini }}"
+    state: directory
+  register: dextractmini

--- a/roles/sngfd_factory_12/tasks/extract.yml
+++ b/roles/sngfd_factory_12/tasks/extract.yml
@@ -21,6 +21,22 @@
     - { in: ".disk/info",                     out: "{{ dextract.path }}/diskinfo" }
     - { in: "pool/main/l/linux-signed-amd64", out: "{{ dextract.path }}/linux-signed-amd64" }
 
+- name: Extracting files from mini ISO if any.
+  when: fn_mini_iso_input != ""
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/xorriso
+      - -osirrox
+      -   "on"
+      - -indev
+      -   "{{ fn_mini_iso_input }}"
+      - -extract
+      -   "{{ item.in }}"
+      -   "{{ item.out }}"
+  loop:
+    - { in: "initrd.gz",                     out: "{{ dextractmini.path }}/initrd.gz" }
+    - { in: "linux",                         out: "{{ dextractmini.path }}/vmlinuz" }
+
 - name: Make some of the extracted files writable.
   ansible.builtin.file:
     path: "{{ item.out }}"

--- a/roles/sngfd_factory_12/tasks/helpers.yml
+++ b/roles/sngfd_factory_12/tasks/helpers.yml
@@ -15,7 +15,7 @@
 - name: Get some static text files in place.
   ansible.builtin.copy:
     src: "{{ item }}"
-    dest: "{{ dtmp.path }}"
+    dest: "{{ dcdrom.path }}"
   loop:
     - README.txt
     - WARNING.txt

--- a/roles/sngfd_factory_12/tasks/main.yml
+++ b/roles/sngfd_factory_12/tasks/main.yml
@@ -42,6 +42,11 @@
   ansible.builtin.include_tasks:
     file: output.yml
 
+- name: Generate PXE boot setup for Cobbler.
+  when: fn_mini_iso_input != ""
+  ansible.builtin.include_tasks:
+    file: pxecob.yml
+
 #- name: test
 #  ansible.builtin.debug:
 #    msg: "testing"

--- a/roles/sngfd_factory_12/tasks/output.yml
+++ b/roles/sngfd_factory_12/tasks/output.yml
@@ -27,40 +27,40 @@
     - { in: "{{ dextract.path }}/grubtheme1", out: "boot/grub/theme/1" }
     - { in: "{{ disolinux.path }}/menu.cfg",    out: "isolinux/menu.cfg" }
     - { in: "{{ disolinux.path }}/splash.png",  out: "isolinux/splash.png" }
-    - { in: "{{ dtmp.path }}/README.txt",     out: "README.txt" }
-    - { in: "{{ dtmp.path }}/WARNING.txt",    out: "WARNING.txt" }
-    - { in: "{{ dtmp.path }}/EULA.txt",       out: "EULA.txt" }
     - { in: "{{ dtmp.path }}/grub.cfg",     out: "boot/grub/grub.cfg" }
-    - { in: "{{ dtmp.path }}/preseed.cfg",  out: "preseed.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_spice_pub.cfg",    out: "preseed_spice_pub.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_spice_oso.cfg",    out: "preseed_spice_oso.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_spice_fog.cfg",    out: "preseed_spice_fog.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_spice_upg.cfg",    out: "preseed_spice_upg.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_spice_int.cfg",    out: "preseed_spice_int.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_start.cfg",    out: "preseed_partman_start.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_finish.cfg",   out: "preseed_partman_finish.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_raid.cfg",       out: "preseed_partman_raid.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_nonraid.cfg",    out: "preseed_partman_nonraid.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_crypto.cfg",     out: "preseed_partman_crypto.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_raid_disk_s.cfg",    out: "preseed_partman_raid_disk_s.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_raid_disk_v.cfg",    out: "preseed_partman_raid_disk_v.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_raid_disk_xv.cfg",   out: "preseed_partman_raid_disk_xv.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_nonraid_disk_s.cfg",   out: "preseed_partman_nonraid_disk_s.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_nonraid_disk_v.cfg",   out: "preseed_partman_nonraid_disk_v.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_nonraid_disk_xv.cfg",  out: "preseed_partman_nonraid_disk_xv.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_raid_pub.cfg",    out: "preseed_partman_recipe_raid_pub.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_nonraid_pub.cfg", out: "preseed_partman_recipe_nonraid_pub.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_raid_oso.cfg",    out: "preseed_partman_recipe_raid_oso.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_nonraid_oso.cfg", out: "preseed_partman_recipe_nonraid_oso.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_raid_fog.cfg",    out: "preseed_partman_recipe_raid_fog.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_nonraid_fog.cfg", out: "preseed_partman_recipe_nonraid_fog.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_raid_upg.cfg",    out: "preseed_partman_recipe_raid_upg.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_nonraid_upg.cfg", out: "preseed_partman_recipe_nonraid_upg.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_raid_int_250.cfg",    out: "preseed_partman_recipe_raid_int_250.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_raid_int_500.cfg",    out: "preseed_partman_recipe_raid_int_500.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_raid_int_1TB.cfg",    out: "preseed_partman_recipe_raid_int_1TB.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_nonraid_int_120.cfg", out: "preseed_partman_recipe_nonraid_int_120.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_nonraid_int_250.cfg", out: "preseed_partman_recipe_nonraid_int_250.cfg" }
+    - { in: "{{ dcdrom.path }}/README.txt",     out: "README.txt" }
+    - { in: "{{ dcdrom.path }}/WARNING.txt",    out: "WARNING.txt" }
+    - { in: "{{ dcdrom.path }}/EULA.txt",       out: "EULA.txt" }
+    - { in: "{{ dcdrom.path }}/preseed.cfg",  out: "preseed.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_spice_pub.cfg",    out: "preseed_spice_pub.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_spice_oso.cfg",    out: "preseed_spice_oso.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_spice_fog.cfg",    out: "preseed_spice_fog.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_spice_upg.cfg",    out: "preseed_spice_upg.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_spice_int.cfg",    out: "preseed_spice_int.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_start.cfg",    out: "preseed_partman_start.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_finish.cfg",   out: "preseed_partman_finish.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_raid.cfg",       out: "preseed_partman_raid.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_nonraid.cfg",    out: "preseed_partman_nonraid.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_crypto.cfg",     out: "preseed_partman_crypto.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_raid_disk_s.cfg",    out: "preseed_partman_raid_disk_s.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_raid_disk_v.cfg",    out: "preseed_partman_raid_disk_v.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_raid_disk_xv.cfg",   out: "preseed_partman_raid_disk_xv.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_s.cfg",   out: "preseed_partman_nonraid_disk_s.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_v.cfg",   out: "preseed_partman_nonraid_disk_v.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_xv.cfg",  out: "preseed_partman_nonraid_disk_xv.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_pub.cfg",    out: "preseed_partman_recipe_raid_pub.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_pub.cfg", out: "preseed_partman_recipe_nonraid_pub.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_oso.cfg",    out: "preseed_partman_recipe_raid_oso.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_oso.cfg", out: "preseed_partman_recipe_nonraid_oso.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_fog.cfg",    out: "preseed_partman_recipe_raid_fog.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_fog.cfg", out: "preseed_partman_recipe_nonraid_fog.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_upg.cfg",    out: "preseed_partman_recipe_raid_upg.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_upg.cfg", out: "preseed_partman_recipe_nonraid_upg.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_int_250.cfg",    out: "preseed_partman_recipe_raid_int_250.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_int_500.cfg",    out: "preseed_partman_recipe_raid_int_500.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_int_1TB.cfg",    out: "preseed_partman_recipe_raid_int_1TB.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_int_120.cfg", out: "preseed_partman_recipe_nonraid_int_120.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_int_250.cfg", out: "preseed_partman_recipe_nonraid_int_250.cfg" }
     - { in: "{{ dcdrom.path }}/20-sangoma.cfg", out: "cdrom/20-sangoma.cfg" }
     - { in: "{{ dcdrom.path }}/sng_boot_all_command",             out: "cdrom/sng_boot_all_command" }
     - { in: "{{ dcdrom.path }}/sng_preseed_chooser_all_command",  out: "cdrom/sng_preseed_chooser_all_command" }
@@ -91,40 +91,40 @@
     - { in: "{{ dextract.path }}/grubtheme1", out: "boot/grub/theme/1" }
     - { in: "{{ disolinux.path }}/menu.cfg",    out: "isolinux/menu.cfg" }
     - { in: "{{ disolinux.path }}/splash.png",  out: "isolinux/splash.png" }
-    - { in: "{{ dtmp.path }}/README.txt",     out: "README.txt" }
-    - { in: "{{ dtmp.path }}/WARNING.txt",    out: "WARNING.txt" }
-    - { in: "{{ dtmp.path }}/EULA.txt",       out: "EULA.txt" }
     - { in: "{{ dtmp.path }}/grub.cfg",     out: "boot/grub/grub.cfg" }
-    - { in: "{{ dtmp.path }}/preseed.cfg",  out: "preseed.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_spice_pub.cfg",    out: "preseed_spice_pub.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_spice_oso.cfg",    out: "preseed_spice_oso.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_spice_fog.cfg",    out: "preseed_spice_fog.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_spice_upg.cfg",    out: "preseed_spice_upg.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_spice_int.cfg",    out: "preseed_spice_int.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_start.cfg",    out: "preseed_partman_start.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_finish.cfg",   out: "preseed_partman_finish.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_raid.cfg",       out: "preseed_partman_raid.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_nonraid.cfg",    out: "preseed_partman_nonraid.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_crypto.cfg",     out: "preseed_partman_crypto.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_raid_disk_s.cfg",    out: "preseed_partman_raid_disk_s.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_raid_disk_v.cfg",    out: "preseed_partman_raid_disk_v.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_raid_disk_xv.cfg",   out: "preseed_partman_raid_disk_xv.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_nonraid_disk_s.cfg",   out: "preseed_partman_nonraid_disk_s.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_nonraid_disk_v.cfg",   out: "preseed_partman_nonraid_disk_v.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_nonraid_disk_xv.cfg",  out: "preseed_partman_nonraid_disk_xv.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_raid_pub.cfg",    out: "preseed_partman_recipe_raid_pub.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_nonraid_pub.cfg", out: "preseed_partman_recipe_nonraid_pub.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_raid_oso.cfg",    out: "preseed_partman_recipe_raid_oso.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_nonraid_oso.cfg", out: "preseed_partman_recipe_nonraid_oso.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_raid_fog.cfg",    out: "preseed_partman_recipe_raid_fog.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_nonraid_fog.cfg", out: "preseed_partman_recipe_nonraid_fog.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_raid_upg.cfg",    out: "preseed_partman_recipe_raid_upg.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_nonraid_upg.cfg", out: "preseed_partman_recipe_nonraid_upg.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_raid_int_250.cfg",    out: "preseed_partman_recipe_raid_int_250.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_raid_int_500.cfg",    out: "preseed_partman_recipe_raid_int_500.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_raid_int_1TB.cfg",    out: "preseed_partman_recipe_raid_int_1TB.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_nonraid_int_120.cfg", out: "preseed_partman_recipe_nonraid_int_120.cfg" }
-    - { in: "{{ dtmp.path }}/preseed_partman_recipe_nonraid_int_250.cfg", out: "preseed_partman_recipe_nonraid_int_250.cfg" }
+    - { in: "{{ dcdrom.path }}/README.txt",     out: "README.txt" }
+    - { in: "{{ dcdrom.path }}/WARNING.txt",    out: "WARNING.txt" }
+    - { in: "{{ dcdrom.path }}/EULA.txt",       out: "EULA.txt" }
+    - { in: "{{ dcdrom.path }}/preseed.cfg",  out: "preseed.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_spice_pub.cfg",    out: "preseed_spice_pub.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_spice_oso.cfg",    out: "preseed_spice_oso.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_spice_fog.cfg",    out: "preseed_spice_fog.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_spice_upg.cfg",    out: "preseed_spice_upg.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_spice_int.cfg",    out: "preseed_spice_int.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_start.cfg",    out: "preseed_partman_start.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_finish.cfg",   out: "preseed_partman_finish.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_raid.cfg",       out: "preseed_partman_raid.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_nonraid.cfg",    out: "preseed_partman_nonraid.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_crypto.cfg",     out: "preseed_partman_crypto.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_raid_disk_s.cfg",    out: "preseed_partman_raid_disk_s.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_raid_disk_v.cfg",    out: "preseed_partman_raid_disk_v.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_raid_disk_xv.cfg",   out: "preseed_partman_raid_disk_xv.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_s.cfg",   out: "preseed_partman_nonraid_disk_s.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_v.cfg",   out: "preseed_partman_nonraid_disk_v.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_xv.cfg",  out: "preseed_partman_nonraid_disk_xv.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_pub.cfg",    out: "preseed_partman_recipe_raid_pub.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_pub.cfg", out: "preseed_partman_recipe_nonraid_pub.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_oso.cfg",    out: "preseed_partman_recipe_raid_oso.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_oso.cfg", out: "preseed_partman_recipe_nonraid_oso.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_fog.cfg",    out: "preseed_partman_recipe_raid_fog.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_fog.cfg", out: "preseed_partman_recipe_nonraid_fog.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_upg.cfg",    out: "preseed_partman_recipe_raid_upg.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_upg.cfg", out: "preseed_partman_recipe_nonraid_upg.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_int_250.cfg",    out: "preseed_partman_recipe_raid_int_250.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_int_500.cfg",    out: "preseed_partman_recipe_raid_int_500.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_int_1TB.cfg",    out: "preseed_partman_recipe_raid_int_1TB.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_int_120.cfg", out: "preseed_partman_recipe_nonraid_int_120.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_int_250.cfg", out: "preseed_partman_recipe_nonraid_int_250.cfg" }
     - { in: "{{ dcdrom.path }}/20-sangoma.cfg", out: "cdrom/20-sangoma.cfg" }
     - { in: "{{ dcdrom.path }}/sng_boot_all_command",             out: "cdrom/sng_boot_all_command" }
     - { in: "{{ dcdrom.path }}/sng_preseed_chooser_all_command",  out: "cdrom/sng_preseed_chooser_all_command" }
@@ -157,13 +157,13 @@
       -   "{{ dextract.path }}/grubtheme1"
       -   "boot/grub/theme/1"
       - -map
-      -   "{{ dtmp.path }}/README.txt"
+      -   "{{ dcdrom.path }}/README.txt"
       -   "README.txt"
       - -map
-      -   "{{ dtmp.path }}/WARNING.txt"
+      -   "{{ dcdrom.path }}/WARNING.txt"
       -   "WARNING.txt"
       - -map
-      -   "{{ dtmp.path }}/EULA.txt"
+      -   "{{ dcdrom.path }}/EULA.txt"
       -   "EULA.txt"
       - -map
       -   "{{ disolinux.path }}/menu.cfg"
@@ -175,94 +175,94 @@
       -   "{{ dtmp.path }}/grub.cfg"
       -   "boot/grub/grub.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed.cfg"
+      -   "{{ dcdrom.path }}/preseed.cfg"
       -   "preseed.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_spice_pub.cfg"
+      -   "{{ dcdrom.path }}/preseed_spice_pub.cfg"
       -   "preseed_spice_pub.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_spice_oso.cfg"
+      -   "{{ dcdrom.path }}/preseed_spice_oso.cfg"
       -   "preseed_spice_oso.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_spice_fog.cfg"
+      -   "{{ dcdrom.path }}/preseed_spice_fog.cfg"
       -   "preseed_spice_fog.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_spice_upg.cfg"
+      -   "{{ dcdrom.path }}/preseed_spice_upg.cfg"
       -   "preseed_spice_upg.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_spice_int.cfg"
+      -   "{{ dcdrom.path }}/preseed_spice_int.cfg"
       -   "preseed_spice_int.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_start.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_start.cfg"
       -   "preseed_partman_start.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_finish.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_finish.cfg"
       -   "preseed_partman_finish.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_raid.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_raid.cfg"
       -   "preseed_partman_raid.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_nonraid.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_nonraid.cfg"
       -   "preseed_partman_nonraid.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_crypto.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_crypto.cfg"
       -   "preseed_partman_crypto.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_raid_disk_s.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_raid_disk_s.cfg"
       -   "preseed_partman_raid_disk_s.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_raid_disk_v.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_raid_disk_v.cfg"
       -   "preseed_partman_raid_disk_v.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_raid_disk_xv.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_raid_disk_xv.cfg"
       -   "preseed_partman_raid_disk_xv.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_nonraid_disk_s.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_nonraid_disk_s.cfg"
       -   "preseed_partman_nonraid_disk_s.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_nonraid_disk_v.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_nonraid_disk_v.cfg"
       -   "preseed_partman_nonraid_disk_v.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_nonraid_disk_xv.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_nonraid_disk_xv.cfg"
       -   "preseed_partman_nonraid_disk_xv.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_recipe_raid_pub.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_raid_pub.cfg"
       -   "preseed_partman_recipe_raid_pub.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_recipe_nonraid_pub.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_pub.cfg"
       -   "preseed_partman_recipe_nonraid_pub.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_recipe_raid_oso.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_raid_oso.cfg"
       -   "preseed_partman_recipe_raid_oso.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_recipe_nonraid_oso.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_oso.cfg"
       -   "preseed_partman_recipe_nonraid_oso.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_recipe_raid_fog.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_raid_fog.cfg"
       -   "preseed_partman_recipe_raid_fog.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_recipe_nonraid_fog.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_fog.cfg"
       -   "preseed_partman_recipe_nonraid_fog.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_recipe_raid_upg.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_raid_upg.cfg"
       -   "preseed_partman_recipe_raid_upg.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_recipe_nonraid_upg.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_upg.cfg"
       -   "preseed_partman_recipe_nonraid_upg.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_recipe_raid_int_250.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_raid_int_250.cfg"
       -   "preseed_partman_recipe_raid_int_250.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_recipe_raid_int_500.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_raid_int_500.cfg"
       -   "preseed_partman_recipe_raid_int_500.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_recipe_raid_int_1TB.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_raid_int_1TB.cfg"
       -   "preseed_partman_recipe_raid_int_1TB.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_recipe_nonraid_int_120.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_int_120.cfg"
       -   "preseed_partman_recipe_nonraid_int_120.cfg"
       - -map
-      -   "{{ dtmp.path }}/preseed_partman_recipe_nonraid_int_250.cfg"
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_int_250.cfg"
       -   "preseed_partman_recipe_nonraid_int_250.cfg"
       - -map
       -   "{{ dcdrom.path }}/20-sangoma.cfg"

--- a/roles/sngfd_factory_12/tasks/preseeds.yml
+++ b/roles/sngfd_factory_12/tasks/preseeds.yml
@@ -7,12 +7,12 @@
 - name: Initial preseed.cfg
   ansible.builtin.template:
     src: preseed.j2
-    dest: "{{ dtmp.path }}/preseed.cfg"
+    dest: "{{ dcdrom.path }}/preseed.cfg"
 
 - name: Spicy preseed_spice_....cfg
   ansible.builtin.template:
     src: preseed_spice.j2
-    dest: "{{ dtmp.path }}/preseed_spice_{{ item.spice }}.cfg"
+    dest: "{{ dcdrom.path }}/preseed_spice_{{ item.spice }}.cfg"
   loop:
     - { stage: "early",           spice: "pub", passbytes: "{{ int_passbytes_pub }}" }
     - { stage: "early",           spice: "oso", passbytes: "{{ int_passbytes_oso }}" }
@@ -20,10 +20,10 @@
     - { stage: "early",           spice: "upg", passbytes: "{{ int_passbytes_upg }}" }
     - { stage: "early",           spice: "int", passbytes: "{{ int_passbytes_int }}" }
 
-- name: Non-disk type specifi partman related preseeds.
+- name: Non-disk type specific partman related preseeds.
   ansible.builtin.template:
     src: "{{ item }}.j2"
-    dest: "{{ dtmp.path }}/{{ item }}.cfg"
+    dest: "{{ dcdrom.path }}/{{ item }}.cfg"
   loop:
     - preseed_partman_start
     - preseed_partman_crypto
@@ -34,7 +34,7 @@
 - name: Unique partman disk types for non-RAID.
   ansible.builtin.template:
     src: preseed_partman_nonraid_disk.j2
-    dest: "{{ dtmp.path }}/preseed_partman_nonraid_disk_{{ item.disk_type }}.cfg"
+    dest: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_{{ item.disk_type }}.cfg"
   loop:
     - { disk_type: "s" }
     - { disk_type: "v" }
@@ -43,7 +43,7 @@
 - name: Unique partman disk types for RAID.
   ansible.builtin.template:
     src: preseed_partman_raid_disk.j2
-    dest: "{{ dtmp.path }}/preseed_partman_raid_disk_{{ item.disk_type }}.cfg"
+    dest: "{{ dcdrom.path }}/preseed_partman_raid_disk_{{ item.disk_type }}.cfg"
   loop:
     - { disk_type: "s" }
     - { disk_type: "v" }
@@ -51,7 +51,7 @@
 
 - name: Physical disks are very "s"pecial - force GPT to help with UEFI (non-RAID).
   ansible.builtin.lineinfile:
-    path: "{{ dtmp.path }}/preseed_partman_nonraid_disk_s.cfg"
+    path: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_s.cfg"
     line: "{{ item }}"
   loop:
     - "d-i partman-partitioning/choose_label select gpt"
@@ -59,7 +59,7 @@
 
 - name: Physical disks are very "s"pecial - force GPT to help with UEFI (RAID).
   ansible.builtin.lineinfile:
-    path: "{{ dtmp.path }}/preseed_partman_raid_disk_s.cfg"
+    path: "{{ dcdrom.path }}/preseed_partman_raid_disk_s.cfg"
     line: "{{ item }}"
   loop:
     - "d-i partman-partitioning/choose_label select gpt"
@@ -68,7 +68,7 @@
 - name: Unique partman recipes for partitioning.
   ansible.builtin.template:
     src: preseed_partman_recipe.j2
-    dest: "{{ dtmp.path }}/preseed_partman_recipe_{{ item.raid }}_{{ item.spice }}.cfg"
+    dest: "{{ dcdrom.path }}/preseed_partman_recipe_{{ item.raid }}_{{ item.spice }}.cfg"
   loop:
     - { raid: "raid",     spice: pub, swapmin: "{{ int_mb_swap_min }}",       swapmax: "{{ int_mb_swap_max }}" }
     - { raid: "nonraid",  spice: pub, swapmin: "{{ int_mb_swap_min }}",       swapmax: "{{ int_mb_swap_max }}" }
@@ -82,7 +82,7 @@
 - name: Unique Partman Recipes for INT Spice Level.
   ansible.builtin.template:
     src: preseed_partman_recipe.j2
-    dest: "{{ dtmp.path }}/preseed_partman_recipe_{{ item.raid }}_{{ item.spice }}_{{ item.size }}.cfg"
+    dest: "{{ dcdrom.path }}/preseed_partman_recipe_{{ item.raid }}_{{ item.spice }}_{{ item.size }}.cfg"
   loop:
     - { raid: "raid",     spice: int, swapmin: "{{ int_mb_swap_warehouse }}",       swapmax: "{{ int_mb_swap_warehouse }}",   root_partition_size: "{{ root_partition_size_250GB  }}",  size: "250" }
     - { raid: "raid",     spice: int, swapmin: "{{ int_mb_swap_warehouse }}",       swapmax: "{{ int_mb_swap_warehouse }}",   root_partition_size: "{{ root_partition_size_500GB  }}",  size: "500" }

--- a/roles/sngfd_factory_12/tasks/pxecob.yml
+++ b/roles/sngfd_factory_12/tasks/pxecob.yml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 Sangoma US Inc.
+#
+# SPDX-License-Identifier: GPL-2.0-only
+---
+# file: sngfd_factory_12/tasks/pxecob.yml
+
+# Description: Sets up PXE boot with Cobbler over the network for faster warehouse factory installs vs. USB stick.
+
+- name: Try to copy an existing Debian installer netboot initrd.
+  ignore_errors: true
+  ansible.builtin.copy:
+    src: "{{ dextractmini.path }}/initrd.gz"
+    dest: "{{ dcdrom.path }}/initrd.gz"
+
+- name: Check if the initrd was copied.
+  ansible.builtin.stat:
+    path: "{{ dcdrom.path }}/initrd.gz"
+  register: initrdgz
+
+- name: Copy preseed.cfg into sample.seed
+  when: initrdgz.stat.exists
+  ansible.builtin.copy:
+    src: "{{ dcdrom.path }}/preseed.cfg"
+    dest: "{{ dcdrom.path }}/sample.seed"
+
+- name: Generate PXE tarball.
+  when: initrdgz.stat.exists
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/tar
+      - -c
+      - -f
+      - "{{ str_iso_out_base }}-PXE.tar"
+      - -C
+      - "{{ dtmp.path }}"
+      - "{{ dn_cdrom }}"
+
+- name: Shell commands to execute on host for using PXE tarball with Cobbler.
+  when: initrdgz.stat.exists
+  ansible.builtin.template:
+    src: run_on_pxe_cobbler_servers.j2
+    dest: "{{ str_iso_out_base }}-RUN-ON-PXE-COBBLER-{{ item.pxe_cob_distro }}.sh"
+  loop:
+    - { pxe_cob_distro: "ROCKY9" }
+    - { pxe_cob_distro: "SNG7" }
+
+- name: Shell command instructions for controller.
+  when: initrdgz.stat.exists
+  ansible.builtin.template:
+    src: run_on_pxe_cobbler_controller.j2
+    dest: "{{ str_iso_out_base }}-RUN-ON-PXE-COBBLER-CONTROLLER-README.txt"

--- a/roles/sngfd_factory_12/templates/bootloader_menu_grub.j2
+++ b/roles/sngfd_factory_12/templates/bootloader_menu_grub.j2
@@ -39,22 +39,30 @@ set color_normal=white/black
 set color_highlight=yellow/black
 set background_color=black
 submenu --hotkey=b 'Basic FreePBX {{ str_freepbx_version }} install {{ str_script_version }}' {
-    menuentry --hotkey=e '(Press Escape to go Back)' {
+    menuentry --hotkey=p '(Press Escape to go Back)' {
         echo ""
     }
 {% set localized = "" %}
 {% for spice in ["PUB", "FOG"] %}
 {% if spice == "UPG" or spice == "INT" %}{% set localized = "locale=en_US language=en country=US keymap=us" %}{% endif %}
     submenu --hotkey={{ spice|lower|first }} 'Auto FreePBX {{ str_freepbx_version }} "{{ spice }}" install {{ str_script_version }}' {
-        menuentry --hotkey=e '(Press Escape to go Back)' {
+        menuentry --hotkey=p '(Press Escape to go Back)' {
             echo ""
         }
         menuentry --hotkey=y 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}"' {
-            linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
+            linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=prod auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
             initrd   /install.amd/initrd.gz
         }
         menuentry --hotkey=s 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (SERIAL)' {
-            linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
+            linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=prod auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
+            initrd   /install.amd/initrd.gz
+        }
+        menuentry --hotkey=t 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (TEST)' {
+            linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=test auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
+            initrd   /install.amd/initrd.gz
+        }
+        menuentry --hotkey=e 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (TEST SERIAL)' {
+            linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=test auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
             initrd   /install.amd/initrd.gz
         }
     }
@@ -85,22 +93,30 @@ submenu --hotkey=b 'Basic FreePBX {{ str_freepbx_version }} install {{ str_scrip
     }
 }
 submenu --hotkey=a 'Advanced FreePBX {{ str_freepbx_version }} install {{ str_script_version }}' {
-    menuentry --hotkey=e '(Press Escape to go Back)' {
+    menuentry --hotkey=p '(Press Escape to go Back)' {
         echo ""
     }
 {% set localized = "" %}
 {% for spice in ["OSO", "UPG", "INT"] %}
 {% if spice == "UPG" or spice == "INT" %}{% set localized = "locale=en_US language=en country=US keymap=us" %}{% endif %}
     submenu --hotkey={{ spice|lower|first }} 'Auto FreePBX {{ str_freepbx_version }} "{{ spice }}" install {{ str_script_version }}' {
-        menuentry --hotkey=e '(Press Escape to go Back)' {
+        menuentry --hotkey=p '(Press Escape to go Back)' {
             echo ""
         }
         menuentry --hotkey=y 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}"' {
-            linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
+            linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=prod auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
             initrd   /install.amd/initrd.gz
         }
         menuentry --hotkey=s 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (SERIAL)' {
-            linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
+            linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=prod auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
+            initrd   /install.amd/initrd.gz
+        }
+        menuentry --hotkey=t 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (TEST)' {
+            linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=test auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
+            initrd   /install.amd/initrd.gz
+        }
+        menuentry --hotkey=e 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (TEST SERIAL)' {
+            linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=test auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
             initrd   /install.amd/initrd.gz
         }
     }

--- a/roles/sngfd_factory_12/templates/bootloader_menu_isolinux.j2
+++ b/roles/sngfd_factory_12/templates/bootloader_menu_isolinux.j2
@@ -24,7 +24,7 @@ menu begin spice{{ spice|lower }}
 		label autofpbx{{ spice|lower }}
 			menu label ^YES WIPE MY DISKS AND INSTALL "{{ spice }}"
 			kernel /install.amd/vmlinuz
-			append spicelevel={{ spice|lower }} initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
+			append spicelevel={{ spice|lower }} fpbxrepo=prod initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
 			text help
 
 
@@ -37,7 +37,33 @@ menu begin spice{{ spice|lower }}
 		label autofpbxserial{{ spice|lower }}
 			menu label YES WIPE MY DISKS AND INSTALL "{{ spice }}" (^SERIAL)
 			kernel /install.amd/vmlinuz
-			append spicelevel={{ spice|lower }} initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
+			append spicelevel={{ spice|lower }} fpbxrepo=prod initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
+			text help
+
+
+	WARNING: The installer will wipe all your disks automatically.
+	MINIMUM DISK SIZE: 30G PUB or FOG // 100G RAID1
+	LEGACY BOOT DETECTED: RAID1 only works in UEFI mode. Check BIOS.
+	This option will send and receive control on the serial port.
+	Version: {{ str_script_version }}    Build: {{ str_script_build }}
+			endtext
+		label autofpbxtest{{ spice|lower }}
+			menu label YES WIPE MY DISKS AND INSTALL "{{ spice }}" (^TEST)
+			kernel /install.amd/vmlinuz
+			append spicelevel={{ spice|lower }} fpbxrepo=test initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
+			text help
+
+
+	WARNING: The installer will wipe all your disks automatically.
+	MINIMUM DISK SIZE: 30G PUB or FOG // 100G RAID1
+	LEGACY BOOT DETECTED: RAID1 only works in UEFI mode. Check BIOS.
+
+	Version: {{ str_script_version }}    Build: {{ str_script_build }}
+			endtext
+		label autofpbxtestserial{{ spice|lower }}
+			menu label YES WIPE MY DISKS AND INSTALL "{{ spice }}" (SERIAL T^EST)
+			kernel /install.amd/vmlinuz
+			append spicelevel={{ spice|lower }} fpbxrepo=test initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
 			text help
 
 
@@ -72,7 +98,7 @@ menu begin spice{{ spice|lower }}
 		label autofpbx{{ spice|lower }}
 			menu label ^YES WIPE MY DISKS AND INSTALL "{{ spice }}"
 			kernel /install.amd/vmlinuz
-			append spicelevel={{ spice|lower }} initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
+			append spicelevel={{ spice|lower }} fpbxrepo=prod initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
 			text help
 
 
@@ -85,7 +111,33 @@ menu begin spice{{ spice|lower }}
 		label autofpbxserial{{ spice|lower }}
 			menu label YES WIPE MY DISKS AND INSTALL "{{ spice }}" (^SERIAL)
 			kernel /install.amd/vmlinuz
-			append spicelevel={{ spice|lower }} initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
+			append spicelevel={{ spice|lower }} fpbxrepo=prod initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
+			text help
+
+
+	WARNING: The installer will wipe all your disks automatically.
+	MINIMUM DISK SIZE: 30G OSO / 40G UPG / 90G INT // 100G RAID1
+	LEGACY BOOT DETECTED: RAID1 only works in UEFI mode. Check BIOS.
+	This option will send and receive control on the serial port.
+	Version: {{ str_script_version }}    Build: {{ str_script_build }}
+			endtext
+		label autofpbxtest{{ spice|lower }}
+			menu label YES WIPE MY DISKS AND INSTALL "{{ spice }}" (^TEST)
+			kernel /install.amd/vmlinuz
+			append spicelevel={{ spice|lower }} fpbxrepo=test initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
+			text help
+
+
+	WARNING: The installer will wipe all your disks automatically.
+	MINIMUM DISK SIZE: 30G OSO / 40G UPG / 90G INT // 100G RAID1
+	LEGACY BOOT DETECTED: RAID1 only works in UEFI mode. Check BIOS.
+
+	Version: {{ str_script_version }}    Build: {{ str_script_build }}
+			endtext
+		label autofpbxtestserial{{ spice|lower }}
+			menu label YES WIPE MY DISKS AND INSTALL "{{ spice }}" (T^EST SERIAL)
+			kernel /install.amd/vmlinuz
+			append spicelevel={{ spice|lower }} fpbxrepo=test initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
 			text help
 
 

--- a/roles/sngfd_factory_12/templates/preseed.j2
+++ b/roles/sngfd_factory_12/templates/preseed.j2
@@ -141,6 +141,11 @@ d-i netcfg/get_hostname string {{ str_host_name }}
 d-i partman/early_command string \
 	mkdir -p /cdrom; \
 	tftp -g -l /cdrom/sng_early_partman_all_command -r /{{ dn_cdrom }}/sng_early_partman_all_command ${tftphost}; \
+	tftp -g -l /cdrom/sng_early_pub_command -r /{{ dn_cdrom }}/sng_early_pub_command ${tftphost}; \
+	tftp -g -l /cdrom/sng_early_oso_command -r /{{ dn_cdrom }}/sng_early_oso_command ${tftphost}; \
+	tftp -g -l /cdrom/sng_early_fog_command -r /{{ dn_cdrom }}/sng_early_fog_command ${tftphost}; \
+	tftp -g -l /cdrom/sng_early_upg_command -r /{{ dn_cdrom }}/sng_early_upg_command ${tftphost}; \
+	tftp -g -l /cdrom/sng_early_int_command -r /{{ dn_cdrom }}/sng_early_int_command ${tftphost}; \
 	tftp -g -l /cdrom/sng_late_all_command -r /{{ dn_cdrom }}/sng_late_all_command ${tftphost}; \
 	tftp -g -l /cdrom/sng_late_pub_command -r /{{ dn_cdrom }}/sng_late_pub_command ${tftphost}; \
 	tftp -g -l /cdrom/sng_late_oso_command -r /{{ dn_cdrom }}/sng_late_oso_command ${tftphost}; \

--- a/roles/sngfd_factory_12/templates/run_on_pxe_cobbler_controller.j2
+++ b/roles/sngfd_factory_12/templates/run_on_pxe_cobbler_controller.j2
@@ -1,0 +1,18 @@
+# Substitute ROCKY9 and SNG7 for the names of your hosts.
+
+export ROCKY9=
+export SNG7=
+
+scp {{ str_iso_out_base }}* $ROCKY9:/tmp
+
+ssh $ROCKY9
+# On ROCKY9:
+sudo sh /tmp/{{ str_iso_out_base }}-RUN-ON-PXE-COBBLER-ROCKY9.sh
+
+# On controller (after ROCKY9):
+scp $ROCKY9:/tmp/{{ str_iso_out_base }}-GRUB-FROM-ROCKY9.tgz .
+scp {{ str_iso_out_base }}* $SNG7:/tmp
+
+ssh $SNG7
+# On SNG7:
+sudo sh /tmp/{{ str_iso_out_base }}-RUN-ON-PXE-COBBLER-SNG7.sh

--- a/roles/sngfd_factory_12/templates/run_on_pxe_cobbler_servers.j2
+++ b/roles/sngfd_factory_12/templates/run_on_pxe_cobbler_servers.j2
@@ -1,0 +1,90 @@
+#!/bin/sh
+
+# Copy over the ISO and the TAR to the cobbler PXE boot server. Then run there AS ROOT:
+
+if [ "x$1" = "x" ]; then
+	echo "Usage: $0 192.0.2.42"
+	echo "Must supply IP of production Cobbler Server as argument."
+	exit
+fi
+
+# Change to whatever your TFTP / PXE boot server IPv4 is:
+COBBLER_SERVER="$1"
+
+# TFTP directory varies by operating system flavor.
+
+# on FC41, Rocky9:
+{% if item.pxe_cob_distro == "ROCKY9" %}
+TFTP_DIR=/var/lib/tftpboot
+{% else %}
+# on CentOS 7 / SNG7:
+TFTP_DIR=/tftpboot
+{% endif %}
+
+# Remove any existing profile/distro with the same name.
+cobbler profile remove --name={{ str_our_short_cap_name }}-PBX{{ str_freepbx_version }}-SERIAL
+cobbler profile remove --name={{ str_our_short_cap_name }}-PBX{{ str_freepbx_version }}-SERIAL-TEST
+cobbler profile remove --name={{ str_our_short_cap_name }}-PBX{{ str_freepbx_version }}-MONITOR
+cobbler profile remove --name={{ str_our_short_cap_name }}-PBX{{ str_freepbx_version }}-MONITOR-TEST
+
+# Blow away any potential old duplicates.
+cobbler profile remove --name={{ str_cob_base }}-x86_64
+cobbler distro remove --name={{ str_cob_base }}-x86_64
+cobbler repo remove --name={{ str_cob_base }}-x86_64
+
+# Stash copy of the new files into /root directory.
+sudo mkdir -p /root/{{ str_iso_out_base }} /root
+sudo cp -ab /tmp/{{ str_iso_out_base }}* /root/{{ str_iso_out_base }}
+
+# Install the new distro.
+cd ${TFTP_DIR}
+tar xf /tmp/{{ str_iso_out_base }}-PXE.tar
+mkdir -p /mnt/{{ str_iso_out_base }}
+mount -t iso9660 -o loop,ro /tmp/{{ fn_iso_output }} /mnt/{{ str_iso_out_base }}
+cobbler import --name={{ str_cob_base }} --arch=x86_64 --path=/mnt/{{ str_iso_out_base }}
+umount /mnt/{{ str_iso_out_base }}
+cobbler distro edit --name={{ str_cob_base }}-x86_64 --initrd=${TFTP_DIR}/{{ dn_cdrom }}/initrd.gz
+
+# Cobbler profile edit by operating system flavor
+
+# On FC41, Rocky9:
+{% if item.pxe_cob_distro == "ROCKY9" %}
+cobbler profile add --name={{ str_our_short_cap_name }}-PBX{{ str_freepbx_version }}-SERIAL --distro={{ str_cob_base }}-x86_64 --autoinstall='' --kernel-options="locale=en_US language=en country=US keymap=us dmraid=false url=tftp://${COBBLER_SERVER}/{{ dn_cdrom }}/./preseed.cfg tftphost=${COBBLER_SERVER} fpbxrepo=prod console=tty0 console=ttyS0,115200n8 spicelevel=int auto=true interface=auto priority=critical"
+cobbler profile add --name={{ str_our_short_cap_name }}-PBX{{ str_freepbx_version }}-SERIAL-TEST --distro={{ str_cob_base }}-x86_64 --autoinstall='' --kernel-options="locale=en_US language=en country=US keymap=us dmraid=false url=tftp://${COBBLER_SERVER}/{{ dn_cdrom }}/./preseed.cfg tftphost=${COBBLER_SERVER} fpbxrepo=test console=tty0 console=ttyS0,115200n8 spicelevel=int auto=true interface=auto priority=critical"
+cobbler profile add --name={{ str_our_short_cap_name }}-PBX{{ str_freepbx_version }}-MONITOR --distro={{ str_cob_base }}-x86_64 --autoinstall='' --kernel-options="locale=en_US language=en country=US keymap=us dmraid=false url=tftp://${COBBLER_SERVER}/{{ dn_cdrom }}/./preseed.cfg tftphost=${COBBLER_SERVER} fpbxrepo=prod spicelevel=int auto=true interface=auto priority=critical"
+cobbler profile add --name={{ str_our_short_cap_name }}-PBX{{ str_freepbx_version }}-MONITOR-TEST --distro={{ str_cob_base }}-x86_64 --autoinstall='' --kernel-options="locale=en_US language=en country=US keymap=us dmraid=false url=tftp://${COBBLER_SERVER}/{{ dn_cdrom }}/./preseed.cfg tftphost=${COBBLER_SERVER} fpbxrepo=test spicelevel=int auto=true interface=auto priority=critical"
+{% else %}
+# On SNG7:
+cobbler profile add --name={{ str_our_short_cap_name }}-PBX{{ str_freepbx_version }}-SERIAL --distro={{ str_cob_base }}-x86_64 --kickstart='' --kopts="locale=en_US language=en country=US keymap=us dmraid=false url=tftp://${COBBLER_SERVER}/{{ dn_cdrom }}/./preseed.cfg tftphost=${COBBLER_SERVER} fpbxrepo=prod console=tty0 console=ttyS0,115200n8 spicelevel=int auto=true interface=auto priority=critical"
+cobbler profile add --name={{ str_our_short_cap_name }}-PBX{{ str_freepbx_version }}-SERIAL-TEST --distro={{ str_cob_base }}-x86_64 --kickstart='' --kopts="locale=en_US language=en country=US keymap=us dmraid=false url=tftp://${COBBLER_SERVER}/{{ dn_cdrom }}/./preseed.cfg tftphost=${COBBLER_SERVER} fpbxrepo=test console=tty0 console=ttyS0,115200n8 spicelevel=int auto=true interface=auto priority=critical"
+cobbler profile add --name={{ str_our_short_cap_name }}-PBX{{ str_freepbx_version }}-MONITOR --distro={{ str_cob_base }}-x86_64 --kickstart='' --kopts="locale=en_US language=en country=US keymap=us dmraid=false url=tftp://${COBBLER_SERVER}/{{ dn_cdrom }}/./preseed.cfg tftphost=${COBBLER_SERVER} fpbxrepo=prod spicelevel=int auto=true interface=auto priority=critical"
+cobbler profile add --name={{ str_our_short_cap_name }}-PBX{{ str_freepbx_version }}-MONITOR-TEST --distro={{ str_cob_base }}-x86_64 --kickstart='' --kopts="locale=en_US language=en country=US keymap=us dmraid=false url=tftp://${COBBLER_SERVER}/{{ dn_cdrom }}/./preseed.cfg tftphost=${COBBLER_SERVER} fpbxrepo=test spicelevel=int auto=true interface=auto priority=critical"
+{% endif %}
+
+# Remove no longer used x86_64 profile.
+cobbler profile remove --name={{ str_cob_base }}-x86_64
+
+# Remove gtk and xen profiles.
+cobbler profile remove --name={{ str_cob_base }}-gtk-x86_64
+cobbler profile remove --name={{ str_cob_base }}-xen-x86_64
+cobbler distro remove --name={{ str_cob_base }}-gtk-x86_64
+cobbler distro remove --name={{ str_cob_base }}-xen-x86_64
+cobbler repo remove --name={{ str_cob_base }}-gtk-x86_64
+cobbler repo remove --name={{ str_cob_base }}-xen-x86_64
+
+# Synchronize cobbler changes.
+cobbler sync
+
+#####################
+
+{% if item.pxe_cob_distro == "ROCKY9" %}
+# If using SNG7, more steps needed.
+# Actually, you can't do it alone -- you'll need to run all of the above on Rocky9.
+# THEN, run this on Rocky9 *BEFORE SNG7*:
+rm -f /tmp/{{ str_iso_out_base }}-GRUB-FROM-ROCKY9.tgz
+tar czf /tmp/{{ str_iso_out_base }}-GRUB-FROM-ROCKY9.tgz -C ${TFTP_DIR} grub
+{% else %}
+# Finally on SNG7 *AFTER ROCKY9*:
+tar xzf /tmp/{{ str_iso_out_base }}-GRUB-FROM-ROCKY9.tgz
+{% endif %}
+

--- a/roles/sngfd_factory_12/templates/sng_late_command.j2
+++ b/roles/sngfd_factory_12/templates/sng_late_command.j2
@@ -37,6 +37,9 @@ fi
 if [ $spicelevel == "fog" ]; then
 	shell_sng_opts=""
 fi
+if [ $fpbxrepo == "test" ] ; then
+	shell_sng_opts="${shell_sng_opts} --testing"
+fi
 
 # systemd oneshot for automatically installing on next reboot
 cat << EOFO > /target/usr/lib/systemd/system/sng-install-freepbx.service


### PR DESCRIPTION
The PXE tarball was not yet ported over from the legacy shell. Also the ISO version naming became compelling to complete while testing the many iterations of the updated PXE work. Further some DAHDI driver mismatch with latest Debian provided kernel meant a detour to add in new TEST and TEST SERIAL boot menu options. Good times.

Fixes: #7 #11