### PR TITLE
Reproducible builds.

### DIFF
--- a/abuild-fpbx-installer-iso
+++ b/abuild-fpbx-installer-iso
@@ -11,13 +11,17 @@ usage() {
 	echo "
 Minimal Usage: $0 -i debian_input.iso
 
-Options:
+Required:
 	-i	Path to input ISO file.
+
+Optional:
+	-b	Build version - defaults to yymm.1 eg. 2504.1 (where .1 is the bump)
 	-p	Path to mini input ISO for network installs with PXE and Cobbler.
 
 Examples:
 	$0 -i /path/to/debian-12.8.0-amd64-netinst.iso
 	$0 -i /path/to/debian-12.8.0-amd64-netinst.iso -p /path/to/mini-debian.iso
+	$0 -i /path/to/debian-12.8.0-amd64-netinst.iso -p /path/to/mini-debian.iso -b 2504.3
 
 You can change more options by setting Ansible variables on a per host or group basis.
 This shell script is a simple wrapper around ansible-playbook to run on your localhost.
@@ -26,8 +30,11 @@ Please see README.md for more information.
 	exit 1
 }
 
-while getopts ":i:p:" opt; do
+while getopts ":i:pb:" opt; do
 	case "${opt}" in
+		b)
+			str_script_build=${OPTARG}
+			;;
 		i)
 			fn_iso_input=${OPTARG}
 			;;
@@ -45,9 +52,19 @@ if [ -z "${fn_iso_input}" ]; then
 	usage
 fi
 
+extra_vars="fn_iso_input=${fn_iso_input}"
+
+if [ -n "${fn_mini_iso_input}" ]; then
+	extra_vars="${extra_vars} fn_mini_iso_input=${fn_mini_iso_input}"
+fi
+
+if [ -n "${str_script_build}" ]; then
+	extra_vars="${extra_vars} str_script_build=${str_script_build}"
+fi
+
 ansible-playbook \
 	--inventory localhost, \
 	--connection=local \
-	--extra-vars "fn_iso_input=${fn_iso_input} fn_mini_iso_input=${fn_mini_iso_input}" \
+	--extra-vars "${extra_vars}" \
 	default-playbook.yml
 

--- a/roles/sngfd_factory_12/defaults/main/defaults.yml
+++ b/roles/sngfd_factory_12/defaults/main/defaults.yml
@@ -18,17 +18,34 @@ str_our_short_cap_name: "SNGDEB"
 
 # Support Debian 12 bookworm
 str_deb_codename: "bookworm"
-str_deb_version: "12"
+#str_deb_version: "12"
 
-# Script versioning - CHANGE THESE TWO WHEN MAKING A NEW ISO
-str_script_minor: "10.0"
-str_script_bump: "2"
+# Must be supplied on command line
+#fn_iso_input: "debian-12.8.0-amd64-netinst.iso"
+#fn_mini_iso_input: "debian-12.8.0-amd64-mini.iso"
+fn_mini_iso_input: ""
+
+# Assuming input ISO follows customary naming convention
+list_iso_input: "{{ fn_iso_input | split('-') }}"
+str_deb_version_full: "{{ list_iso_input[1] }}"
+list_deb_version_full: "{{ str_deb_version_full | split('.') }}"
+str_deb_version: "{{ list_deb_version_full[0] }}"
+str_deb_version_minor: "{{ list_deb_version_full[1] }}.{{ list_deb_version_full[2] }}"
+
+# Script versioning
+#str_script_minor: "10.0"
+str_script_minor: "{{ str_deb_version_minor }}"
+
+# Bumping version mostly controlled from command line
+str_script_bump: "1"
 
 # Architecture
 str_arch: "amd64"
 
 # Computed values
 str_script_build: "{{ '%y%m' | strftime }}.{{ str_script_bump }}"
+str_script_build_fakedate: "20{{ str_script_build | split('.') | first }}{{ str_script_build | split('.') | last | regex_replace('^([1-9])$','0\\1') }}123456"
+str_script_source_date_epoch: "{{ (str_script_build_fakedate | to_datetime('%Y%m%d%H%M%S')).strftime('%s') }}"
 str_script_codename: "{{ str_deb_codename }}"
 str_script_major: "{{ str_deb_version }}"
 str_script_version: "{{ str_script_major }}.{{ str_script_minor }}.{{ str_script_build }}"
@@ -197,10 +214,6 @@ dir_archives: ""
 # Sensible default
 fn_netboot_initrd: ""
 #fn_netboot_initrd: "{{ str_script_codename }}-netboot-initrd.gz"
-
-# Must be supplied on command line
-#fn_iso_input: "debian-12.8.0-amd64-netinst.iso"
-#fn_mini_iso_input: "debian-12.8.0-amd64-mini.iso"
 
 # Used to depend on DIY and SPICE... back in the legacy shell days...
 fn_iso_output: "{{ str_iso_out_base }}.iso"

--- a/roles/sngfd_factory_12/tasks/output.yml
+++ b/roles/sngfd_factory_12/tasks/output.yml
@@ -140,6 +140,8 @@
 
 - name: Run xorriso to generate ISO output.
   ignore_errors: true
+  environment:
+    SOURCE_DATE_EPOCH: "{{ str_script_source_date_epoch }}"
   ansible.builtin.command:
     argv:
       - /usr/bin/xorriso
@@ -426,6 +428,11 @@
       - --
       - -volid
       -   "{{ str_our_short_cap_name }}_{{ str_script_version_underscore }}_{{ str_spice }}{{ str_diy }}"
+      - alter_date_r
+      -   b
+      -   "{{ str_script_source_date_epoch }}"
+      -   /
+      - --
       - -md5
       -   all
       - -boot_image

--- a/roles/sngfd_factory_12/templates/header.j2
+++ b/roles/sngfd_factory_12/templates/header.j2
@@ -4,7 +4,7 @@
 #
 # Check if this is Original Goods at https://FreePBX.com
 #
-# Date: {{ '%Y-%m-%d %H:%M:%S' | strftime }}
+# Date: {{ str_script_build_fakedate }}
 # Script Name: {{ str_script_name }}
 # Script Build: {{ str_script_build }}
 # Script Version: {{ str_script_version }}


### PR DESCRIPTION
When run multiple times in the same month, on the same underlying code, the output ISO will be bit-for-bit the same each time. The build version can be faked as well, using the -b option to the shell wrapper. The -b option is also useful for increasing the bump version eg. 2505.2 would be the second build in May 2025.

Resolves: #20