### PR TITLE
Mini ISO is dynamic on command line now - needed extra colon.

### DIFF
--- a/abuild-fpbx-installer-iso
+++ b/abuild-fpbx-installer-iso
@@ -30,7 +30,7 @@ Please see README.md for more information.
 	exit 1
 }
 
-while getopts ":i:pb:" opt; do
+while getopts ":i:p:b:" opt; do
 	case "${opt}" in
 		b)
 			str_script_build=${OPTARG}


### PR DESCRIPTION
Minor typo in the option argument processing in the shell script that wraps the ansible role was preventing the generation of needed files for PXE Cobbler boot/installation server configuration.