### PR TITLE
Time stamps on files in output ISO was incorrect.

### DIFF
--- a/roles/sngfd_factory_12/tasks/output.yml
+++ b/roles/sngfd_factory_12/tasks/output.yml
@@ -430,7 +430,7 @@
       -   "{{ str_our_short_cap_name }}_{{ str_script_version_underscore }}_{{ str_spice }}{{ str_diy }}"
       - alter_date_r
       -   b
-      -   "{{ str_script_source_date_epoch }}"
+      -   ={{ str_script_source_date_epoch }}
       -   /
       - --
       - -md5


### PR DESCRIPTION
Adding an equals sign into xorriso command to properly set output file timestamps to calculated epoch. (Previously the date was always locking to 1997.) Reproduceability is now maintained for same build versions e.g. -b 2509.1 will show September 1st, 2025 at 12:34pm Mountain time.