### PR TITLE
sync in new version of shell installer that includes ASTVERSION default

### DIFF
--- a/roles/sngfd_factory_12/files/sng_freepbx_debian_install.sh
+++ b/roles/sngfd_factory_12/files/sng_freepbx_debian_install.sh
@@ -23,7 +23,7 @@
 #####################################################################################
 set -e
 SCRIPTVER="1.15"
-ASTVERSION=22
+ASTVERSION=${ASTVERSION:-22}
 PHPVERSION="8.2"
 LOG_FOLDER="/var/log/pbx"
 LOG_FILE="${LOG_FOLDER}/freepbx17-install-$(date '+%Y.%m.%d-%H.%M.%S').log"


### PR DESCRIPTION
This should make switching between Asterisk versions easier.

The copy of the shell installer that is included in the ISO is potentially useful if the download of the current copy of the shell installer from GitHub were to fail for some reason.