### PR TITLE
New SLAB and NVME options, plus bootloader menu improvements.

### DIFF
--- a/roles/sngfd_factory_12/tasks/output.yml
+++ b/roles/sngfd_factory_12/tasks/output.yml
@@ -50,6 +50,7 @@
     - { in: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_s.cfg",   out: "preseed_partman_nonraid_disk_s.cfg" }
     - { in: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_v.cfg",   out: "preseed_partman_nonraid_disk_v.cfg" }
     - { in: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_xv.cfg",  out: "preseed_partman_nonraid_disk_xv.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_nvme.cfg",  out: "preseed_partman_nonraid_disk_nvme.cfg" }
     - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_pub.cfg",    out: "preseed_partman_recipe_raid_pub.cfg" }
     - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_pub.cfg", out: "preseed_partman_recipe_nonraid_pub.cfg" }
     - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_oso.cfg",    out: "preseed_partman_recipe_raid_oso.cfg" }
@@ -63,6 +64,19 @@
     - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_int_1TB.cfg",    out: "preseed_partman_recipe_raid_int_1TB.cfg" }
     - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_int_120.cfg", out: "preseed_partman_recipe_nonraid_int_120.cfg" }
     - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_int_250.cfg", out: "preseed_partman_recipe_nonraid_int_250.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_pub.cfg",    out: "preseed_partman_recipe_slabraid_pub.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_pub.cfg", out: "preseed_partman_recipe_slabnonraid_pub.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_oso.cfg",    out: "preseed_partman_recipe_slabraid_oso.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_oso.cfg", out: "preseed_partman_recipe_slabnonraid_oso.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_fog.cfg",    out: "preseed_partman_recipe_slabraid_fog.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_fog.cfg", out: "preseed_partman_recipe_slabnonraid_fog.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_upg.cfg",    out: "preseed_partman_recipe_slabraid_upg.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_upg.cfg", out: "preseed_partman_recipe_slabnonraid_upg.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_int_250.cfg",    out: "preseed_partman_recipe_slabraid_int_250.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_int_500.cfg",    out: "preseed_partman_recipe_slabraid_int_500.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_int_1TB.cfg",    out: "preseed_partman_recipe_slabraid_int_1TB.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_int_120.cfg", out: "preseed_partman_recipe_slabnonraid_int_120.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_int_250.cfg", out: "preseed_partman_recipe_slabnonraid_int_250.cfg" }
     - { in: "{{ dcdrom.path }}/20-sangoma.cfg", out: "cdrom/20-sangoma.cfg" }
     - { in: "{{ dcdrom.path }}/sng_boot_all_command",             out: "cdrom/sng_boot_all_command" }
     - { in: "{{ dcdrom.path }}/sng_preseed_chooser_all_command",  out: "cdrom/sng_preseed_chooser_all_command" }
@@ -114,6 +128,7 @@
     - { in: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_s.cfg",   out: "preseed_partman_nonraid_disk_s.cfg" }
     - { in: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_v.cfg",   out: "preseed_partman_nonraid_disk_v.cfg" }
     - { in: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_xv.cfg",  out: "preseed_partman_nonraid_disk_xv.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_nvme.cfg",  out: "preseed_partman_nonraid_disk_nvme.cfg" }
     - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_pub.cfg",    out: "preseed_partman_recipe_raid_pub.cfg" }
     - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_pub.cfg", out: "preseed_partman_recipe_nonraid_pub.cfg" }
     - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_oso.cfg",    out: "preseed_partman_recipe_raid_oso.cfg" }
@@ -127,6 +142,19 @@
     - { in: "{{ dcdrom.path }}/preseed_partman_recipe_raid_int_1TB.cfg",    out: "preseed_partman_recipe_raid_int_1TB.cfg" }
     - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_int_120.cfg", out: "preseed_partman_recipe_nonraid_int_120.cfg" }
     - { in: "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_int_250.cfg", out: "preseed_partman_recipe_nonraid_int_250.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_pub.cfg",    out: "preseed_partman_recipe_slabraid_pub.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_pub.cfg", out: "preseed_partman_recipe_slabnonraid_pub.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_oso.cfg",    out: "preseed_partman_recipe_slabraid_oso.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_oso.cfg", out: "preseed_partman_recipe_slabnonraid_oso.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_fog.cfg",    out: "preseed_partman_recipe_slabraid_fog.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_fog.cfg", out: "preseed_partman_recipe_slabnonraid_fog.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_upg.cfg",    out: "preseed_partman_recipe_slabraid_upg.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_upg.cfg", out: "preseed_partman_recipe_slabnonraid_upg.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_int_250.cfg",    out: "preseed_partman_recipe_slabraid_int_250.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_int_500.cfg",    out: "preseed_partman_recipe_slabraid_int_500.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_int_1TB.cfg",    out: "preseed_partman_recipe_slabraid_int_1TB.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_int_120.cfg", out: "preseed_partman_recipe_slabnonraid_int_120.cfg" }
+    - { in: "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_int_250.cfg", out: "preseed_partman_recipe_slabnonraid_int_250.cfg" }
     - { in: "{{ dcdrom.path }}/20-sangoma.cfg", out: "cdrom/20-sangoma.cfg" }
     - { in: "{{ dcdrom.path }}/sng_boot_all_command",             out: "cdrom/sng_boot_all_command" }
     - { in: "{{ dcdrom.path }}/sng_preseed_chooser_all_command",  out: "cdrom/sng_preseed_chooser_all_command" }
@@ -254,6 +282,9 @@
       -   "{{ dcdrom.path }}/preseed_partman_nonraid_disk_xv.cfg"
       -   "preseed_partman_nonraid_disk_xv.cfg"
       - -map
+      -   "{{ dcdrom.path }}/preseed_partman_nonraid_disk_nvme.cfg"
+      -   "preseed_partman_nonraid_disk_nvme.cfg"
+      - -map
       -   "{{ dcdrom.path }}/preseed_partman_recipe_raid_pub.cfg"
       -   "preseed_partman_recipe_raid_pub.cfg"
       - -map
@@ -292,6 +323,45 @@
       - -map
       -   "{{ dcdrom.path }}/preseed_partman_recipe_nonraid_int_250.cfg"
       -   "preseed_partman_recipe_nonraid_int_250.cfg"
+      - -map
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_pub.cfg"
+      -   "preseed_partman_recipe_slabraid_pub.cfg"
+      - -map
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_pub.cfg"
+      -   "preseed_partman_recipe_slabnonraid_pub.cfg"
+      - -map
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_oso.cfg"
+      -   "preseed_partman_recipe_slabraid_oso.cfg"
+      - -map
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_oso.cfg"
+      -   "preseed_partman_recipe_slabnonraid_oso.cfg"
+      - -map
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_fog.cfg"
+      -   "preseed_partman_recipe_slabraid_fog.cfg"
+      - -map
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_fog.cfg"
+      -   "preseed_partman_recipe_slabnonraid_fog.cfg"
+      - -map
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_upg.cfg"
+      -   "preseed_partman_recipe_slabraid_upg.cfg"
+      - -map
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_upg.cfg"
+      -   "preseed_partman_recipe_slabnonraid_upg.cfg"
+      - -map
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_int_250.cfg"
+      -   "preseed_partman_recipe_slabraid_int_250.cfg"
+      - -map
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_int_500.cfg"
+      -   "preseed_partman_recipe_slabraid_int_500.cfg"
+      - -map
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_slabraid_int_1TB.cfg"
+      -   "preseed_partman_recipe_slabraid_int_1TB.cfg"
+      - -map
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_int_120.cfg"
+      -   "preseed_partman_recipe_slabnonraid_int_120.cfg"
+      - -map
+      -   "{{ dcdrom.path }}/preseed_partman_recipe_slabnonraid_int_250.cfg"
+      -   "preseed_partman_recipe_slabnonraid_int_250.cfg"
       - -map
       -   "{{ dcdrom.path }}/20-sangoma.cfg"
       -   "20-sangoma.cfg"

--- a/roles/sngfd_factory_12/tasks/preseeds.yml
+++ b/roles/sngfd_factory_12/tasks/preseeds.yml
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Sangoma US Inc.
-#
+# SPDX-FileCopyrightText: 2026 Sangoma US Inc.
 # SPDX-License-Identifier: GPL-2.0-only
 ---
 # file: sngfd_factory_12/tasks/preseeds.yml
@@ -39,6 +38,7 @@
     - { disk_type: "s" }
     - { disk_type: "v" }
     - { disk_type: "xv" }
+    - { disk_type: "nvme" }
     
 - name: Unique partman disk types for RAID.
   ansible.builtin.template:
@@ -65,6 +65,14 @@
     - "d-i partman-partitioning/choose_label select gpt"
     - "d-i partman-partitioning/default_label string gpt"
 
+- name: Physical disks are very "s"pecial - force GPT to help with UEFI (non-RAID) - NVME.
+  ansible.builtin.lineinfile:
+    path: "{{ dcdrom.path }}/preseed_partman_nonraid_disk_nvme.cfg"
+    line: "{{ item }}"
+  loop:
+    - "d-i partman-partitioning/choose_label select gpt"
+    - "d-i partman-partitioning/default_label string gpt"
+
 - name: Unique partman recipes for partitioning.
   ansible.builtin.template:
     src: preseed_partman_recipe.j2
@@ -83,6 +91,31 @@
   ansible.builtin.template:
     src: preseed_partman_recipe.j2
     dest: "{{ dcdrom.path }}/preseed_partman_recipe_{{ item.raid }}_{{ item.spice }}_{{ item.size }}.cfg"
+  loop:
+    - { raid: "raid",     spice: int, swapmin: "{{ int_mb_swap_warehouse }}",       swapmax: "{{ int_mb_swap_warehouse }}",   root_partition_size: "{{ root_partition_size_250GB  }}",  size: "250" }
+    - { raid: "raid",     spice: int, swapmin: "{{ int_mb_swap_warehouse }}",       swapmax: "{{ int_mb_swap_warehouse }}",   root_partition_size: "{{ root_partition_size_500GB  }}",  size: "500" }
+    - { raid: "raid",     spice: int, swapmin: "{{ int_mb_swap_warehouse }}",       swapmax: "{{ int_mb_swap_warehouse }}",   root_partition_size: "{{ root_partition_size_1TB  }}",  size: "1TB" }
+    - { raid: "nonraid",  spice: int, swapmin: "{{ int_mb_swap_warehouse }}",       swapmax: "{{ int_mb_swap_warehouse }}",   root_partition_size: "{{ root_partition_size_120GB  }}",  size: "120" }
+    - { raid: "nonraid",  spice: int, swapmin: "{{ int_mb_swap_warehouse }}",       swapmax: "{{ int_mb_swap_warehouse }}",   root_partition_size: "{{ root_partition_size_250GB  }}",  size: "250" }
+
+- name: Unique partman recipes for partitioning on one slab disk.
+  ansible.builtin.template:
+    src: preseed_partman_recipe_slab.j2
+    dest: "{{ dcdrom.path }}/preseed_partman_recipe_slab{{ item.raid }}_{{ item.spice }}.cfg"
+  loop:
+    - { raid: "raid",     spice: pub, swapmin: "{{ int_mb_swap_min }}",       swapmax: "{{ int_mb_swap_max }}" }
+    - { raid: "nonraid",  spice: pub, swapmin: "{{ int_mb_swap_min }}",       swapmax: "{{ int_mb_swap_max }}" }
+    - { raid: "raid",     spice: oso, swapmin: "{{ int_mb_swap_min }}",       swapmax: "{{ int_mb_swap_max }}" }
+    - { raid: "nonraid",  spice: oso, swapmin: "{{ int_mb_swap_min }}",       swapmax: "{{ int_mb_swap_max }}" }
+    - { raid: "raid",     spice: fog, swapmin: "{{ int_mb_swap_min }}",       swapmax: "{{ int_mb_swap_max }}" }
+    - { raid: "nonraid",  spice: fog, swapmin: "{{ int_mb_swap_min }}",       swapmax: "{{ int_mb_swap_max }}" }
+    - { raid: "raid",     spice: upg, swapmin: "{{ int_mb_swap_existing }}",  swapmax: "{{ int_mb_swap_existing }}" }
+    - { raid: "nonraid",  spice: upg, swapmin: "{{ int_mb_swap_existing }}",  swapmax: "{{ int_mb_swap_existing }}" }
+
+- name: Unique Partman Recipes for INT Spice Level on one disk slab.
+  ansible.builtin.template:
+    src: preseed_partman_recipe_slab.j2
+    dest: "{{ dcdrom.path }}/preseed_partman_recipe_slab{{ item.raid }}_{{ item.spice }}_{{ item.size }}.cfg"
   loop:
     - { raid: "raid",     spice: int, swapmin: "{{ int_mb_swap_warehouse }}",       swapmax: "{{ int_mb_swap_warehouse }}",   root_partition_size: "{{ root_partition_size_250GB  }}",  size: "250" }
     - { raid: "raid",     spice: int, swapmin: "{{ int_mb_swap_warehouse }}",       swapmax: "{{ int_mb_swap_warehouse }}",   root_partition_size: "{{ root_partition_size_500GB  }}",  size: "500" }

--- a/roles/sngfd_factory_12/templates/bootloader_menu_grub.j2
+++ b/roles/sngfd_factory_12/templates/bootloader_menu_grub.j2
@@ -1,3 +1,38 @@
+{# The choice JINJA2 macro builds the final choice command line. #}
+{# Parameters: #}
+{# _opt     the shortcut key, probably a number 1-5 #}
+{# _spice   Spice level, three upper case letters #}
+{# _astver  Asterisk version number #}
+{# _test    Set to 'test' to use FreePBX test package repository #}
+{# _serial  Set to 'serial' to make I/O over the serial port #}
+{# _disk    Set to 'slab' to make swap plus one boot and one large root partition #}
+{% macro choice(_opt, _spice, _astver, _test='', _serial='', _disk='') -%}
+{% set localized = "" %}
+{% if _spice == "UPG" or _spice == "INT" %}
+{% set localized = "locale=en_US language=en country=US keymap=us" %}
+{% endif %}
+            submenu "INSTALL AND WIPE DISKS '{{ _spice }}' {{ (_test|upper ~ ' ' ~ _serial|upper ~ ' ' ~ _disk|upper)|trim }}" --hotkey={{ _opt }} {
+                menuentry "(Press Escape to go Back) f{{ str_freepbx_version }} a{{ astver }} d{{ str_script_version }}" {
+                    echo ""
+                    play {{ tangotune }}
+                }
+                menuentry "YES, I confirm, wipe disks and install '{{ _spice }}' {{ (_test|upper ~ ' ' ~ _serial|upper ~ ' ' ~ _disk|upper)|trim }}" --hotkey=y {
+                    echo ""
+                    echo "Installation about to begin..."
+                    echo ""
+                    echo "THIRTY SECONDS UNTIL ALL DATA WILL BE ERASED FROM YOUR DISKS!"
+                    echo "*This includes any USB drives larger than appx. 100 GB.*"
+                    echo "Power off now if unsure."
+                    echo ""
+                    echo "f{{ str_freepbx_version }} a{{ _astver }} d{{ str_script_version }} '{{ _spice }}' {{ (_test|upper ~ ' ' ~ _serial|upper ~ ' ' ~ _disk|upper)|trim }}"
+                    echo ""
+                    sleep --verbose 30
+                    linux   /install.amd/vmlinuz spicelevel={{ _spice|lower }} fpbxrepo={{ _test|default('prod',true) }} asteriskversion={{ _astver }} auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} {% if _serial == '' %}vga=788{% else %}console=tty0 console=ttyS0,115200n8{% endif %} {% if _disk != '' %}sngdiskrecipe={{ _disk }}{% endif %} --- quiet
+                    initrd  /install.amd/initrd.gz
+                }
+            }
+{%- endmacro %}
+{% set tangotune = "600 800 1 600 1 700 1 500 1 300 1 0 1 900 1" %}
 if [ x$feature_default_font_path = xy ] ; then
    font=unicode
 else
@@ -18,17 +53,17 @@ fi
 
 if background_image /isolinux/splash.png; then
   set color_normal=light-gray/black
-  set color_highlight=white/black
+  set color_highlight=light-green/black
 elif background_image /splash.png; then
   set color_normal=light-gray/black
-  set color_highlight=white/black
+  set color_highlight=light-green/black
 else
   set color_normal=light-gray/black
-  set color_highlight=white/black
+  set color_highlight=light-green/black
 fi
 
 insmod play
-play 600 800 1 600 1 700 1 500 1 300 1 0 1 900 1
+play {{ tangotune }}
 set theme=/boot/grub/theme/1
 
 serial --unit=0 --speed=115200
@@ -36,217 +71,175 @@ terminal_input --append serial
 terminal_output --append serial
 
 set menu_color_normal=white/black
-set menu_color_highlight=yellow/black
+set menu_color_highlight=light-green/black
 set color_normal=white/black
-set color_highlight=yellow/black
+set color_highlight=light-green/black
 set background_color=black
 
-submenu --hotkey=b 'Basic FreePBX {{ str_freepbx_version }} install {{ str_script_version }}' {
-    menuentry --hotkey=p '(Press Escape to go Back)' {
+menuentry "FreePBX {{ str_freepbx_version }} Distro {{ str_script_version }}" --hotkey=b {
+    echo ""
+    echo "Tango the frog our FreePBX mascot wants you to hop over to"
+    echo "our community forums for free help, tips, and discussion at:"
+    echo ""
+    echo "          https://community.freepbx.org"
+    echo ""
+    echo "Kit the robot our Asterisk mascot suggests you transport to"
+    echo "our annual physical Asterisk community meeting, AstriCon:"
+    echo ""
+    echo "          https://astricon.net"
+    echo ""
+    echo "And your friends at Sangoma want to thank you for using FreePBX!"
+    echo ""
+    echo "          https://sangoma.com"
+    echo ""
+    play {{ tangotune }}
+    sleep --verbose --interruptible 30
+}
+
+{% set spice = 'INT' %}
+{% set astver = '22' %}
+submenu "Advanced INTernal Sangoma Install" --hotkey=a {
+    menuentry "(Press Escape to go Back) f{{ str_freepbx_version }} a{{ astver }} d{{ str_script_version }}" {
         echo ""
+        play {{ tangotune }}
     }
-    {% set localized = "" %}
-    {% for spice in ["PUB", "FOG"] %}
-        {% for astver in [21,22] %}
-            {% if spice == "UPG" or spice == "INT" %}
-                {% set localized = "locale=en_US language=en country=US keymap=us" %}
-            {% endif %}
+{{ choice('i', spice, astver) }}
+{{ choice('s', spice, astver, '', 'serial') }}
+{{ choice('l', spice, astver, '', '', 'slab') }}
+{{ choice('r', spice, astver, '', 'serial', 'slab') }}
+{{ choice('t', spice, astver, 'test') }}
+}
 
-            {% set base_hotkey = spice|lower|first %}
-            {% if astver == 21 %}
-                {% set hotkey = base_hotkey %}
-            {% else %}
-                {% set hotkey = base_hotkey.upper() %}
-            {% endif %}
-
-            submenu --hotkey={{ hotkey }} 'Auto FreePBX {{ str_freepbx_version }} "{{ spice }}" install {{ str_script_version }} with Asterisk {{ astver }}' {
-                menuentry --hotkey=p '(Press Escape to go Back)' {
-                    echo ""
-                }
-                menuentry --hotkey=y 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}"' {
-                    linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=prod asteriskversion={{ astver }} auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
-                    initrd   /install.amd/initrd.gz
-                }
-                menuentry --hotkey=s 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (SERIAL)' {
-                    linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=prod asteriskversion={{ astver }} auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
-                    initrd   /install.amd/initrd.gz
-                }
-                menuentry --hotkey=t 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (TEST)' {
-                    linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=test asteriskversion={{ astver }} auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
-                    initrd   /install.amd/initrd.gz
-                }
-                menuentry --hotkey=e 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (TEST SERIAL)' {
-                    linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=test asteriskversion={{ astver }} auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
-                    initrd   /install.amd/initrd.gz
-                }
+submenu "Other installation options" --hotkey=o {
+{% for spice in ["PUB", "FOG", "OSO", "UPG"] %}
+    submenu "Spice Level '{{ spice }}'" --hotkey={{ spice[0]|lower }} {
+{% for astver in ["18", "20", "21", "22", "23"] %}
+        submenu "Asterisk version {{ astver }}" --hotkey={{ astver[-1] }} {
+            menuentry "(Press Escape to go Back) f{{ str_freepbx_version }} a{{ astver }} d{{ str_script_version }}" {
+                echo ""
+                play {{ tangotune }}
             }
-        {% endfor %}
-    {% endfor %}
-    menuentry '.........................' {
-        echo ""
+{{ choice('i', spice, astver) }}
+{{ choice('s', spice, astver, '', 'serial') }}
+{{ choice('l', spice, astver, '', '', 'slab') }}
+{{ choice('r', spice, astver, '', 'serial', 'slab') }}
+{{ choice('t', spice, astver, 'test') }}
+        }
+{% endfor %}
     }
-    menuentry 'PUB is for the PUBlic. MINIMUM DISK 30G.' {
-        echo ""
+{% endfor %}
+}
+
+submenu "Troubleshooting" --hotkey=t {
+    menuentry "Rescue mode" --hotkey=r {
+        linux   /install.amd/vmlinuz rescue/enable=true
+        initrd  /install.amd/initrd.gz
     }
-    menuentry 'PUB installs with DAHDI and matched kernel.' {
-        echo ""
+    menuentry "Rescue mode (VGA)" --hotkey=v {
+        linux   /install.amd/vmlinuz vga=788 rescue/enable=true
+        initrd  /install.amd/initrd.gz
     }
-    menuentry 'PUB displays the randomly generated password for the {{ str_whoami }} user.' {
-        echo ""
+    menuentry "Rescue mode (SERIAL)" --hotkey=s {
+        linux   /install.amd/vmlinuz rescue/enable=true console=tty0 console=ttyS0,115200n8
+        initrd  /install.amd/initrd.gz
     }
-    menuentry '.........................' {
-        echo ""
+    menuentry "Install stock Debian {{ str_deb_version_full }} without preseed" --hotkey=p {
+        linux   /install.amd/vmlinuz
+        initrd  /install.amd/initrd.gz
     }
-    menuentry 'FOG is for the cloud. MINIMUM DISK 30G.' {
-        echo ""
+    menuentry "Install stock Debian {{ str_deb_version_full }} without preseed (SERIAL)" --hotkey=i {
+        linux   /install.amd/vmlinuz console=tty0 console=ttyS0,115200n8
+        initrd  /install.amd/initrd.gz
     }
-    menuentry 'FOG installs without DAHDI or matched kernel.' {
-        echo ""
+    menuentry "Linux on sda1" --hotkey=a {
+        set     root=(hd0,1)
+        linux   /boot/vmlinuz root=/dev/sda1 ro
+        initrd  /boot/initrd.img
     }
-    menuentry 'FOG displays the randomly generated password for the {{ str_whoami }} user.' {
-        echo ""
+    menuentry "Linux on sdb1" --hotkey=b {
+        set     root=(hd1,1)
+        linux   /boot/vmlinuz root=/dev/sdb1 ro
+        initrd  /boot/initrd.img
+    }
+    menuentry "Linux on nvme0n1" --hotkey=n {
+        set     root=(hd0,1)
+        linux   /boot/vmlinuz root=/dev/nvme0n1 ro
+        initrd  /boot/initrd.img
+    }
+    menuentry "Chainload on disk 1" --hotkey=h {
+        insmod  chain
+        set     root=(hd0)
+        chainloader +1
+    }
+    menuentry "Chainload on disk 2" --hotkey=o {
+        insmod  chain
+        set     root=(hd1)
+        chainloader +1
     }
 }
 
-submenu --hotkey=a 'Advanced FreePBX {{ str_freepbx_version }} install {{ str_script_version }}' {
-    menuentry --hotkey=p '(Press Escape to go Back)' {
-        echo ""
-    }
-    {% set localized = "" %}
-    {% for spice in ["OSO", "UPG", "INT"] %}
-        {% if spice == "INT" %}
-            {% set localized = "locale=en_US language=en country=US keymap=us" %}
-            submenu --hotkey={{ spice|lower|first }} 'Auto FreePBX {{ str_freepbx_version }} "{{ spice }}" install {{ str_script_version }}' {
-                menuentry --hotkey=p '(Press Escape to go Back)' {
-                    echo ""
-                }
-                menuentry --hotkey=y 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}"' {
-                    linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=prod asteriskversion=22 auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
-                    initrd   /install.amd/initrd.gz
-                }
-                menuentry --hotkey=s 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (SERIAL)' {
-                    linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=prod asteriskversion=22 auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
-                    initrd   /install.amd/initrd.gz
-                }
-                menuentry --hotkey=t 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (TEST)' {
-                    linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=test asteriskversion=22 auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
-                    initrd   /install.amd/initrd.gz
-                }
-                menuentry --hotkey=e 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (TEST SERIAL)' {
-                    linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=test asteriskversion=22 auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
-                    initrd   /install.amd/initrd.gz
-                }
-            }
-        {% else %}
-            {% for astver in [21,22] %}
-                {% if spice == "UPG" %}
-                    {% set localized = "locale=en_US language=en country=US keymap=us" %}
-                {% endif %}
-
-                {% set base_hotkey = spice|lower|first %}
-                {% if astver == 21 %}
-                    {% set hotkey = base_hotkey %}
-                {% else %}
-                    {% set hotkey = base_hotkey.upper() %}
-                {% endif %}
-
-                submenu --hotkey={{ hotkey }} 'Auto FreePBX {{ str_freepbx_version }} "{{ spice }}" install {{ str_script_version }} with Asterisk {{ astver }}' {
-                    menuentry --hotkey=p '(Press Escape to go Back)' {
-                        echo ""
-                    }
-                    menuentry --hotkey=y 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}"' {
-                        linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=prod asteriskversion={{ astver }} auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
-                        initrd   /install.amd/initrd.gz
-                    }
-                    menuentry --hotkey=s 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (SERIAL)' {
-                        linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=prod asteriskversion={{ astver }} auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
-                        initrd   /install.amd/initrd.gz
-                    }
-                    menuentry --hotkey=t 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (TEST)' {
-                        linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=test asteriskversion={{ astver }} auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
-                        initrd   /install.amd/initrd.gz
-                    }
-                    menuentry --hotkey=e 'YES AUTOMATICALLY WIPE MY DISK AND INSTALL "{{ spice }}" (TEST SERIAL)' {
-                        linux    /install.amd/vmlinuz spicelevel={{ spice|lower }} fpbxrepo=test asteriskversion={{ astver }} auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
-                        initrd   /install.amd/initrd.gz
-                    }
-                }
-            {% endfor %}
-        {% endif %}
-    {% endfor %}
-    menuentry '.........................' {
-        echo ""
-    }
-    menuentry 'OSO is Open Source Only. MINIMUM DISK 30G.' {
-        echo ""
-    }
-    menuentry 'OSO installs without DAHDI or matched kernel.' {
-        echo ""
-    }
-    menuentry 'OSO uses FreePBX opensourceonly option.' {
-        echo ""
-    }
-    menuentry 'OSO displays the randomly generated password for the {{ str_whoami }} user.' {
-        echo ""
-    }
-    menuentry '.........................' {
-        echo ""
-    }
-    menuentry 'UPG is for UPGrading existing Sangoma appliances. MINIMUM DISK 40G.' {
-        echo ""
-    }
-    menuentry 'UPG uses DAHDI and matched kernel.' {
-        echo ""
-    }
-    menuentry 'UPG locks swap to {{ int_mb_swap_existing }}M and lets you pick password for {{ str_whoami }} user.' {
-        echo ""
-    }
-    menuentry '.........................' {
-        echo ""
-    }
-    menuentry 'INT is for INTernal factory new Sangoma appliances. MINIMUM DISK 90G.' {
-        echo ""
-    }
-    menuentry 'INT uses DAHDI and matched kernel.' {
-        echo ""
-    }
-    menuentry 'INT locks swap to {{ int_mb_swap_warehouse }}M and sets {{ str_whoami }} user password to {{ str_old_user_pass }}' {
-        echo ""
-    }
-}
-
-menuentry --hotkey=r 'Rescue mode' {
-    linux    /install.amd/vmlinuz vga=788 rescue/enable=true
-    initrd   /install.amd/initrd.gz
-}
-
-menuentry --hotkey=s 'Rescue mode (SERIAL)' {
-    linux    /install.amd/vmlinuz rescue/enable=true console=tty0 console=ttyS0,115200n8
-    initrd   /install.amd/initrd.gz
-}
-
-menuentry --hotkey=h 'Help tips' {
+submenu "Help" --hotkey=h {
+    menuentry "Tips" --hotkey=t {
     echo ""
     echo "WARNING: The installer will wipe all your disks automatically."
     echo "         Did you take a backup of any important existing data ?"
     echo ""
-    echo "RAID1 is automatic on disks > ~100G -- make sure you use a smaller USB"
+    echo "RAID1 is automatic on disks over 100G -- please use only small USB"
     echo "to install from; otherwise, it will become part of the RAID array."
-    echo "Disk minimums: PUB,OSO,FOG>30G  UPG>40G  INT>90G"
-    echo "PUB is for the PUBlic. FOG for cloud. Good if new to FreePBX."
+    echo ""
+    echo "Disk minimums: 40G for PUB,OSO,FOG,UPG and 100G for INT,RAID"
+    echo ""
     echo "The SERIAL options will send and receive control on the serial port."
+    echo "The SLAB options will make only boot, root and swap partitions."
     echo ""
     echo "Please visit https://FreePBX.org for more detailed information."
     echo ""
-    echo "Script Name: {{ str_script_name }}"
-    echo "Script Build: {{ str_script_build }}"
-    echo "Script Version: {{ str_script_version }}"
-    echo "FreePBX Version: {{ str_freepbx_version }}"
-    echo "Spiciness: {{ str_spice }}"
-    echo "SFPBX output ISO: {{ fn_iso_output }}"
+    echo "Distro Version: {{ str_script_version }}"
+    echo "ISO Name: {{ fn_iso_output }}"
     echo ""
     echo "Press ESCAPE to go back to the main installer menu"
     sleep --verbose --interruptible 60
+    }
+
+    menuentry "Spice level information" --hotkey=s {
+    echo ""
+    echo "PUB is for the PUBlic. MINIMUM DISK 40G."
+    echo "PUB installs with DAHDI and matched kernel."
+    echo "PUB displays the randomly generated password for the {{ str_whoami }} user."
+    echo ""
+    echo "FOG is for the cloud. MINIMUM DISK 40G."
+    echo "FOG installs without DAHDI or matched kernel."
+    echo "FOG displays the randomly generated password for the {{ str_whoami }} user."
+    echo ""
+    echo "OSO is Open Source Only. MINIMUM DISK 40G."
+    echo "OSO installs without DAHDI or matched kernel."
+    echo "OSO uses FreePBX opensourceonly option."
+    echo "OSO displays the randomly generated password for the {{ str_whoami }} user."
+    echo ""
+    echo "UPG is for UPGrading existing Sangoma appliances. MINIMUM DISK 40G."
+    echo "UPG uses DAHDI and matched kernel."
+    echo "UPG locks swap to {{ int_mb_swap_existing }}M and lets you pick password for {{ str_whoami }} user."
+    echo ""
+    echo "INT is for INTernal factory new Sangoma appliances. MINIMUM DISK 100G."
+    echo "INT uses DAHDI and matched kernel."
+    echo "INT locks swap to {{ int_mb_swap_warehouse }}M and sets {{ str_whoami }} user password to {{ str_old_user_pass }}"
+    echo ""
+    echo "Press ESCAPE to go back to the main installer menu"
+    sleep --verbose --interruptible 60
+    }
+    menuentry "Read README.txt" --hotkey=r {
+        cat /README.txt
+        sleep --verbose --interruptible 60
+    }
+    menuentry "Read WARNING.txt" --hotkey=w {
+        cat /WARNING.txt
+        sleep --verbose --interruptible 60
+    }
+    menuentry "Read summary EULA.txt now - Read full https://Sangoma.com/legal on your own" --hotkey=u {
+        cat /EULA.txt
+        sleep --verbose --interruptible 60
+    }
 }
-set default=saved
+
+#set default=saved
 set timeout=-1

--- a/roles/sngfd_factory_12/templates/bootloader_menu_isolinux.j2
+++ b/roles/sngfd_factory_12/templates/bootloader_menu_isolinux.j2
@@ -1,176 +1,132 @@
-menu hshift 2
-menu width 70
-menu title {{ str_our_full_name }} BIOS Installer menu
+{# The choice JINJA2 macro builds the final choice command line. #}
+{# Parameters: #}
+{# _opt     the shortcut key, probably a number 1-5 #}
+{# _spice   Spice level, three upper case letters #}
+{# _astver  Asterisk version number #}
+{# _test    Set to 'test' to use FreePBX test package repository #}
+{# _serial  Set to 'serial' to make I/O over the serial port #}
+{# _disk    Set to 'slab' to make swap plus one boot and one large root partition #}
+{% macro choice(_opt, _spice, _astver, _test='', _serial='', _disk='') -%}
+{% set localized = "" %}
+{% if _spice == "UPG" or _spice == "INT" %}
+{% set localized = "locale=en_US language=en country=US keymap=us" %}
+{% endif %}
+            label autofpbx{{ _test }}{{ _serial }}{{ _disk }}{{ _spice|lower }}{{ _astver }}
+                menu label ^{{ _opt }} YES WIPE DISKS AND INSTALL "{{ _spice }}" {{ (_test|upper ~ ' ' ~ _serial|upper ~ ' ' ~ _disk|upper)|trim }}
+                kernel /install.amd/vmlinuz
+                append spicelevel={{ _spice|lower }} fpbxrepo={{ _test|default('prod',true) }} asteriskversion={{ _astver }} initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} {% if _serial == '' %}vga=788{% else %}console=tty0 console=ttyS0,115200n8{% endif %} {% if _disk != '' %}sngdiskrecipe={{ _disk }}{% endif %} --- quiet
+                text help
+    WARNING: The installer will wipe all your disks automatically.
+    {% if _disk == '' %}MINIMUM DISK SIZE: 40G PUB, FOG, OSO, UPG // 100G INT, RAID1{% else %}SLAB disk only makes boot, root and swap partitions{% endif %}.
+    LEGACY BOOT DETECTED: RAID1 only works in UEFI mode. Check BIOS.
+    {% if _serial != '' %}SERIAL option will send and receive control on the serial port{% else %}Visit our forums https://community.freepbx.org for free help{% endif %}.
+    Version: {{ str_script_version }}    Build: {{ str_script_build }}
+                endtext
+
+{%- endmacro %}
+
 include stdmenu.cfg
-menu begin basicfpbx
-	menu label ^Basic FreePBX {{ str_freepbx_version }} install {{ str_script_version }}
-		menu title Basic FreePBX {{ str_freepbx_version }} install {{ str_script_version }}
-		include stdmenu.cfg
-		label mainmenubasic
-			menu label ^Back...
-			menu exit
-{% set localized = "" %}
-{% for spice in ["PUB", "FOG"] %}
-{% if spice == "UPG" or spice == "INT" %}
-	{% set localized = "locale=en_US language=en country=US keymap=us" %}
+menu hshift 0
+menu width 70
+menu helpmsgrow 16
+
+menu title {{ str_our_full_name }} BIOS Installer menu
+
+label howdy
+    menu label "Howdy!" says ^Tango the FreePBX mascot :-)
+    text help
+    FreePBX installs best when your network uses DHCP with DNS.
+    Machine will reboot twice during the appx. 20 minute install.
+    LEGACY BOOT DETECTED: RAID1 only works in UEFI mode. Check BIOS.
+    WARNING: The installer will wipe all your disks automatically.
+    WARNING: Any USB drives over 100G will become RAID1 members.
+    endtext
+
+menu begin beginfreepbxmenu
+    menu title Choose installer spice level for FreePBX {{ str_freepbx_version }}
+    menu label ^Begin FreePBX {{ str_freepbx_version }} install {{ str_script_version }}
+
+    label mainmenubegin
+        menu label ^Back...
+        menu exit
+        text help
+    PUB: For the PUBlic - start here if new.
+    FOG: For clouds and other virtualizations.
+    OSO: Open Source Only - AKA "bear mode".
+    UPG: For UPGrades on physical devices.
+    INT: INTernal Sangoma use on new appliances.
+        endtext
+
+{% for spice in ["PUB", "FOG", "OSO", "UPG", "INT"] %}
+    menu begin {{ spice }}menu
+        menu title Choose initial Asterisk version
+        menu label "^{{ spice }}" spice
+
+        label mainmenu{{ spice|lower }}
+            menu label ^Back...
+            menu exit
+            text help
+    18: Long Term Support EOL 2025-10-20
+    20: Long Term Support EOL 2027-10-19
+    21: Standard release  EOL 2026-10-18
+    22: Long Term Support EOL 2029-10-16
+    23: Standard release  EOL 2027-10-15
+            endtext
+
+{% for astver in ["18", "20", "21", "22", "23"] %}
+{% if not (spice == "INT" and not astver == "22") %}
+        menu begin {{ spice }}{{ astver }}menu
+            menu title Install "{{ spice }}" FreePBX {{ str_freepbx_version }} with Asterisk {{ astver }}
+            menu label Install "{{ spice }}" FreePBX {{ str_freepbx_version }} with Asterisk {{ astver[0] }}^{{ astver[-1] }}
+
+            label mainmenu{{ spice|lower }}{{ astver }}
+                menu label ^Back...
+                menu exit
+                text help
+    WARNING: The installer will wipe all your disks automatically.
+    WARNING: The installer will wipe all your disks automatically.
+    WARNING: Any USB drives over 100G will become RAID1 members.
+    WARNING: Any USB drives over 100G will become RAID1 members.
+    Version: {{ str_script_version }}    Build: {{ str_script_build }}
+                endtext
+
+{{ choice('1', spice, astver) }}
+{{ choice('2', spice, astver, '', 'serial') }}
+{{ choice('3', spice, astver, '', '', 'slab') }}
+{{ choice('4', spice, astver, '', 'serial', 'slab') }}
+{{ choice('5', spice, astver, 'test') }}
+        menu end
+
 {% endif %}
-menu begin spice{{ spice|lower }}
-	menu label Auto FreePBX {{ str_freepbx_version }} "^{{ spice }}" install {{ str_script_version }}
-		menu title Auto FreePBX {{ str_freepbx_version }} "{{ spice }}" disk wipe install
-		include stdmenu.cfg
-		label mainmenu{{ spice|lower }}
-			menu label ^Back...
-			menu exit
-		label autofpbx{{ spice|lower }}
-			menu label ^YES WIPE MY DISKS AND INSTALL "{{ spice }}"
-			kernel /install.amd/vmlinuz
-			append spicelevel={{ spice|lower }} fpbxrepo=prod initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
-			text help
+{% endfor %}
+    menu end
 
-
-	WARNING: The installer will wipe all your disks automatically.
-	MINIMUM DISK SIZE: 30G PUB or FOG // 100G RAID1
-	LEGACY BOOT DETECTED: RAID1 only works in UEFI mode. Check BIOS.
-
-	Version: {{ str_script_version }}    Build: {{ str_script_build }}
-			endtext
-		label autofpbxserial{{ spice|lower }}
-			menu label YES WIPE MY DISKS AND INSTALL "{{ spice }}" (^SERIAL)
-			kernel /install.amd/vmlinuz
-			append spicelevel={{ spice|lower }} fpbxrepo=prod initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
-			text help
-
-
-	WARNING: The installer will wipe all your disks automatically.
-	MINIMUM DISK SIZE: 30G PUB or FOG // 100G RAID1
-	LEGACY BOOT DETECTED: RAID1 only works in UEFI mode. Check BIOS.
-	This option will send and receive control on the serial port.
-	Version: {{ str_script_version }}    Build: {{ str_script_build }}
-			endtext
-		label autofpbxtest{{ spice|lower }}
-			menu label YES WIPE MY DISKS AND INSTALL "{{ spice }}" (^TEST)
-			kernel /install.amd/vmlinuz
-			append spicelevel={{ spice|lower }} fpbxrepo=test initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
-			text help
-
-
-	WARNING: The installer will wipe all your disks automatically.
-	MINIMUM DISK SIZE: 30G PUB or FOG // 100G RAID1
-	LEGACY BOOT DETECTED: RAID1 only works in UEFI mode. Check BIOS.
-
-	Version: {{ str_script_version }}    Build: {{ str_script_build }}
-			endtext
-		label autofpbxtestserial{{ spice|lower }}
-			menu label YES WIPE MY DISKS AND INSTALL "{{ spice }}" (SERIAL T^EST)
-			kernel /install.amd/vmlinuz
-			append spicelevel={{ spice|lower }} fpbxrepo=test initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
-			text help
-
-
-	WARNING: The installer will wipe all your disks automatically.
-	MINIMUM DISK SIZE: 30G PUB or FOG // 100G RAID1
-	LEGACY BOOT DETECTED: RAID1 only works in UEFI mode. Check BIOS.
-	This option will send and receive control on the serial port.
-	Version: {{ str_script_version }}    Build: {{ str_script_build }}
-			endtext
-menu end
 {% endfor %}
 menu end
-menu begin advancedfpbx
-	menu label ^Advanced FreePBX {{ str_freepbx_version }} install {{ str_script_version }}
-		menu title Advanced FreePBX {{ str_freepbx_version }} install {{ str_script_version }}
-		include stdmenu.cfg
-		label mainmenuadvanced
-			menu label ^Back...
-			menu exit
-{% set localized = "" %}
-{% for spice in ["OSO", "UPG", "INT"] %}
-{% if spice == "UPG" or spice == "INT" %}
-	{% set localized = "locale=en_US language=en country=US keymap=us" %}
-{% endif %}
-menu begin spice{{ spice|lower }}
-	menu label Auto FreePBX {{ str_freepbx_version }} "^{{ spice }}" install {{ str_script_version }}
-		menu title Auto FreePBX {{ str_freepbx_version }} "{{ spice }}" disk wipe install
-		include stdmenu.cfg
-		label mainmenu{{ spice|lower }}
-			menu label ^Back...
-			menu exit
-		label autofpbx{{ spice|lower }}
-			menu label ^YES WIPE MY DISKS AND INSTALL "{{ spice }}"
-			kernel /install.amd/vmlinuz
-			append spicelevel={{ spice|lower }} fpbxrepo=prod initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
-			text help
 
-
-	WARNING: The installer will wipe all your disks automatically.
-	MINIMUM DISK SIZE: 30G OSO / 40G UPG / 90G INT // 100G RAID1
-	LEGACY BOOT DETECTED: RAID1 only works in UEFI mode. Check BIOS.
-
-	Version: {{ str_script_version }}    Build: {{ str_script_build }}
-			endtext
-		label autofpbxserial{{ spice|lower }}
-			menu label YES WIPE MY DISKS AND INSTALL "{{ spice }}" (^SERIAL)
-			kernel /install.amd/vmlinuz
-			append spicelevel={{ spice|lower }} fpbxrepo=prod initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
-			text help
-
-
-	WARNING: The installer will wipe all your disks automatically.
-	MINIMUM DISK SIZE: 30G OSO / 40G UPG / 90G INT // 100G RAID1
-	LEGACY BOOT DETECTED: RAID1 only works in UEFI mode. Check BIOS.
-	This option will send and receive control on the serial port.
-	Version: {{ str_script_version }}    Build: {{ str_script_build }}
-			endtext
-		label autofpbxtest{{ spice|lower }}
-			menu label YES WIPE MY DISKS AND INSTALL "{{ spice }}" (^TEST)
-			kernel /install.amd/vmlinuz
-			append spicelevel={{ spice|lower }} fpbxrepo=test initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} vga=788 --- quiet
-			text help
-
-
-	WARNING: The installer will wipe all your disks automatically.
-	MINIMUM DISK SIZE: 30G OSO / 40G UPG / 90G INT // 100G RAID1
-	LEGACY BOOT DETECTED: RAID1 only works in UEFI mode. Check BIOS.
-
-	Version: {{ str_script_version }}    Build: {{ str_script_build }}
-			endtext
-		label autofpbxtestserial{{ spice|lower }}
-			menu label YES WIPE MY DISKS AND INSTALL "{{ spice }}" (T^EST SERIAL)
-			kernel /install.amd/vmlinuz
-			append spicelevel={{ spice|lower }} fpbxrepo=test initrd=/install.amd/initrd.gz auto=true file=/cdrom/preseed.cfg dmraid=false priority=critical interface=auto {{ localized }} console=tty0 console=ttyS0,115200n8 --- quiet
-			text help
-
-
-	WARNING: The installer will wipe all your disks automatically.
-	MINIMUM DISK SIZE: 30G OSO / 40G UPG / 90G INT // 100G RAID1
-	LEGACY BOOT DETECTED: RAID1 only works in UEFI mode. Check BIOS.
-	This option will send and receive control on the serial port.
-	Version: {{ str_script_version }}    Build: {{ str_script_build }}
-			endtext
-menu end
-{% endfor %}
-menu end
 label rescue
-	menu label ^Rescue mode
-	kernel /install.amd/vmlinuz
-	append vga=788 initrd=/install.amd/initrd.gz rescue/enable=true
+    menu label ^Rescue mode
+    kernel /install.amd/vmlinuz
+    append vga=788 initrd=/install.amd/initrd.gz rescue/enable=true
+    text help
+    Attempt to recover your system in rescue mode.
+    endtext
+
 label rescueserial
-	menu label R^escue mode (SERIAL)
-	kernel /install.amd/vmlinuz
-	append initrd=/install.amd/initrd.gz rescue/enable=true console=tty0 console=ttyS0,115200n8
-	text help
+    menu label R^escue mode (SERIAL)
+    kernel /install.amd/vmlinuz
+    append initrd=/install.amd/initrd.gz rescue/enable=true console=tty0 console=ttyS0,115200n8
+    text help
+    Attempt to recover your system in rescue mode.
+    SERIAL will send and receive control on the serial port.
+    endtext
 
-
-	This option will send and receive control on the serial port.
-	endtext
 label help
-	menu label ^Help tips
-	text help
-
-
-	Heads up - this is the old BIOS installer. Instead, you might
-	try the UEFI installer. (Check your BIOS.) And take a backup!
-	PUB is for the PUBlic. FOG for cloud. Good if new to FreePBX.
-	WARNING: The installer will wipe all your disks automatically.
-	Version: {{ str_script_version }}    Build: {{ str_script_build }}
-	endtext
+    menu label ^Help tips
+    text help
+    Heads up - this is the old BIOS installer. Instead, you might
+    try the UEFI installer. (Check your BIOS.) And take a backup!
+    Visit our forums https://community.freepbx.org for free help.
+    WARNING: The installer will wipe all your disks automatically.
+    Version: {{ str_script_version }}    Build: {{ str_script_build }}
+    endtext

--- a/roles/sngfd_factory_12/templates/preseed_partman_nonraid_disk.j2
+++ b/roles/sngfd_factory_12/templates/preseed_partman_nonraid_disk.j2
@@ -1,7 +1,13 @@
 {% include 'header.j2' %}
 
-# one disk
-d-i partman-auto/disk string /dev/{{ item.disk_type }}da
+{% if item.disk_type == "nvme" %}
+    {% set disk_suffix="0n1" %}
+{% else %}
+    {% set disk_suffix="da" %}
+{% endif %}
 
-# typically grub installed on '{{ item.disk_type }}da'
-d-i grub-installer/bootdev string /dev/{{ item.disk_type }}da
+# one disk
+d-i partman-auto/disk string /dev/{{ item.disk_type }}{{ disk_suffix }}
+
+# typically grub installed on '{{ item.disk_type }}{{ disk_suffix }}'
+d-i grub-installer/bootdev string /dev/{{ item.disk_type }}{{ disk_suffix }}

--- a/roles/sngfd_factory_12/templates/preseed_partman_recipe_slab.j2
+++ b/roles/sngfd_factory_12/templates/preseed_partman_recipe_slab.j2
@@ -1,0 +1,78 @@
+{% include 'header.j2' %}
+
+# Expert recipe. Very tasty.
+d-i partman-auto/choose_recipe select sng_slab{{ item.raid }}_recipe
+
+# The recipe itself. Probably where the spice nomenclature was first pondered...
+d-i partman-auto/expert_recipe string			\
+sng_slab{{ item.raid }}_recipe ::				\
+	1 1 1 free					\
+		label{ sngnonefi }			\
+		$iflabel{ msdos }			\
+		$reusemethod{ }				\
+		method{ biosgrub }			\
+		format{ }				\
+	.						\
+	768 788 1024 free				\
+		label{ sngefi }				\
+		$iflabel{ gpt }				\
+		$reusemethod{ }				\
+		method{ efi }				\
+		format{ }				\
+	.						\
+{% if item.raid == "raid" %}
+	768 788 1024 raid				\
+		method{ raid }				\
+{% else %}
+	768 788 1024 ext4				\
+		method{ format }			\
+		use_filesystem{ }			\
+		filesystem{ ext4 }			\
+		mountpoint{ /boot }			\
+		options/discard{ discard }		\
+{% endif %}
+		label{ sngboot }			\
+		format{ }				\
+	.						\
+{% if item.spice == "int" %}
+	10 10240 {{ int_mb_ssd_wear }} free				\
+{% else %}
+	10 500 {{ int_mb_ssd_wear }} free				\
+{% endif %}
+		label{ sngssdwear }			\
+		method{ keep }				\
+		options/discard{ discard }		\
+{% if item.raid == "raid" %}
+	.						\
+	3500 9999 -1 raid				\
+		label{ sngraid }			\
+		method{ raid }				\
+		format{ }				\
+{% else %}
+		$iflabel{ gpt }				\
+{% endif %}
+	.						\
+	{{ item.swapmin }} 777 {{ item.swapmax }} linux-swap		\
+		label{ sngswap }			\
+		$defaultignore{ }			\
+		$lvmok{ }				\
+		lv_name{ lvswap }			\
+		method{ swap }				\
+		format{ }				\
+	.						\
+	3500 9999 -1 ext4				\
+		label{ sngroot }			\
+		$defaultignore{ }			\
+		$lvmok{ }				\
+		lv_name{ lvroot }			\
+		method{ format }			\
+		format{ }				\
+		use_filesystem{ }			\
+		filesystem{ ext4 }			\
+		mountpoint{ / }				\
+		options/discard{ discard }		\
+	.
+
+{% if item.raid == "nonraid" %}
+d-i partman-auto/method string lvm
+{% endif %}

--- a/roles/sngfd_factory_12/templates/sng_early_partman_command.j2
+++ b/roles/sngfd_factory_12/templates/sng_early_partman_command.j2
@@ -32,7 +32,7 @@ pvremove -f -f -y /dev/md5 /dev/md6 /dev/md7 /dev/md8 /dev/md9 || true
 sync
 
 logger -t sng "REMOVING PARTITIONS FROM RAID ARRAYS"
-for disk in $(list-devices disk | grep -e 'da$' -e 'db$' -e 'dc$' -e 'dd$' -e 'de$' | cut -f3 -d/); do
+for disk in $(list-devices disk | grep -e 'd[a-e]$' -e 'nvme[0-9]n[0-9]$' | cut -f3 -d/); do
 	for partition in $(list-devices partition | grep $disk); do
 		for raid in 0 1 2 3 4 5 6 7 8 9; do
 			mdadm --fail /dev/md${raid} ${partition} || true
@@ -53,7 +53,7 @@ for raid in 0 1 2 3 4 5 6 7 8 9; do
 done
 sync
 
-for disk in $(list-devices disk | grep -e 'da$' -e 'db$' | cut -f3 -d/); do
+for disk in $(list-devices disk | grep -e 'd[a-b]$' -e 'nvme[0-9]n[0-9]$' | cut -f3 -d/); do
 	logger -t sng "INSPECTING disk ${disk}"
 	size=$(cat /sys/block/${disk}/size)
 	logger -t sng "SIZE disk ${disk} is ${size}"
@@ -82,7 +82,7 @@ done
 sync
 
 logger -t sng "AGAIN REMOVING PARTITIONS FROM RAID ARRAYS"
-for disk in $(list-devices disk | grep -e 'da$' -e 'db$' -e 'dc$' -e 'dd$' -e 'de$' | cut -f3 -d/); do
+for disk in $(list-devices disk | grep -e 'd[a-e]$' -e 'nvme[0-9]n[0-9]$' | cut -f3 -d/); do
 	for partition in $(list-devices partition | grep $disk); do
 		for raid in 0 1 2 3 4 5 6 7 8 9; do
 			mdadm --fail /dev/md${raid} ${partition} || true

--- a/roles/sngfd_factory_12/templates/sng_late_command.j2
+++ b/roles/sngfd_factory_12/templates/sng_late_command.j2
@@ -516,6 +516,11 @@ fi
 
 # most of what is left goes to the spool
 lvresize -l +90%FREE /dev/mapper/pbxvg0-lvvarspool
+
+# except if using slab disk recipe with only boot and root
+if [ $sngdiskrecipe == "slab" ]; then
+    lvresize -l +100%FREE /dev/mapper/pbxvg0-lvroot
+fi
 set -e
 
 sync

--- a/roles/sngfd_factory_12/templates/sng_preseed_chooser_command.j2
+++ b/roles/sngfd_factory_12/templates/sng_preseed_chooser_command.j2
@@ -6,6 +6,8 @@ logger -t sng "BEGIN PRESEED CHOOSER COMMAND"
 
 logger -t sng "SPICE ${spicelevel}"
 
+logger -t sng "DISK ${sngdiskrecipe}"
+
 echo "preseed_partman_start.cfg"
 logger -t sng "CHOSE preseed_partman_start.cfg"
 
@@ -17,13 +19,13 @@ raid=true
 # TODO: nvm "disks" like the UC25 do not show up yet
 # need to load mmc-modules earlier... or move the chooser around...
 # until then dcount=0 on these small devices :-/
-dtype=$(list-devices disk | grep -e 'da$' | cut -f3 -d/ | head -c 1)
-dcount=$(list-devices disk | grep -e 'da$' -e 'db$' | wc -l)
+dtype=$(list-devices disk | grep -e 'da$' -e 'nvme[0-9]n[0-9]$' | cut -f3 -d/ | head -c 1)
+dcount=$(list-devices disk | grep -e 'd[a-b]$' -e 'nvme[0-9]n[0-9]$' | wc -l)
 
 if [ $dcount -le 1 ]; then
 	raid=false
 else
-	for disk in $(list-devices disk | grep -e 'da$' -e 'db$' | cut -f3 -d/); do
+	for disk in $(list-devices disk | grep -e 'd[a-b]$' -e 'nvme[0-9]n[0-9]$' | cut -f3 -d/); do
 		size=$(cat /sys/block/${disk}/size)
 		# TODO: compare sizes of disks and check within 5% diff for RAID
 		# FreePBX 60 single disk size is 250069680 (120GB)
@@ -43,12 +45,15 @@ if $raid; then
 	elif [ "$dtype" = "x" ]; then
 		echo "preseed_partman_raid_disk_xv.cfg"
 		logger -t sng "CHOSE preseed_partman_raid_disk_xv.cfg"
+	elif [ "$dtype" = "n" ]; then
+		echo "preseed_partman_raid_disk_nvme.cfg"
+		logger -t sng "CHOSE preseed_partman_raid_disk_nvme.cfg"
 	else
 		echo "preseed_partman_raid_disk_s.cfg"
 		logger -t sng "CHOSE preseed_partman_raid_disk_s.cfg"
 	fi
 	if [ "$spicelevel" = "int" ]; then
-		disk_part=$(list-devices disk | grep -e 'da$' | cut -f3 -d/)
+		disk_part=$(list-devices disk | grep -e 'da$' -e 'nvme[0-9]n[0-9]$' | cut -f3 -d/)
                 disk_size=$(awk '{print $1 * 512/ 1024/ 1024/ 1024 }' /sys/block/${disk_part}/size)
                 result=$(eval "awk 'BEGIN {
                		 if ($disk_size <= 250) print 1;
@@ -56,18 +61,18 @@ if $raid; then
                 	 else print 3;
                		 }'")
            	if [ "$result" -eq 1 ] || [ "$disk_part" = "" ]; then
-                	echo "preseed_partman_recipe_raid_${spicelevel}_250.cfg"
-                	logger -t sng "CHOSE preseed_partman_recipe_raid_${spicelevel}_250.cfg"
+                	echo "preseed_partman_recipe_${sngdiskrecipe}raid_${spicelevel}_250.cfg"
+                	logger -t sng "CHOSE preseed_partman_recipe_${sngdiskrecipe}raid_${spicelevel}_250.cfg"
         	elif [ "$result" -eq 2 ]; then
-                	echo "preseed_partman_recipe_raid_${spicelevel}_500.cfg"
-                	logger -t sng "CHOSE preseed_partman_recipe_raid_${spicelevel}_500.cfg"
+                	echo "preseed_partman_recipe_${sngdiskrecipe}raid_${spicelevel}_500.cfg"
+                	logger -t sng "CHOSE preseed_partman_recipe_${sngdiskrecipe}raid_${spicelevel}_500.cfg"
         	else
-                	echo "preseed_partman_recipe_raid_${spicelevel}_1TB.cfg"
-                	logger -t sng "CHOSE preseed_partman_recipe_raid_${spicelevel}_1TB.cfg"
+                	echo "preseed_partman_recipe_${sngdiskrecipe}raid_${spicelevel}_1TB.cfg"
+                	logger -t sng "CHOSE preseed_partman_recipe_${sngdiskrecipe}raid_${spicelevel}_1TB.cfg"
         	fi
 	else
-		echo "preseed_partman_recipe_raid_${spicelevel}.cfg"
-		logger -t sng "CHOSE preseed_partman_recipe_raid_${spicelevel}.cfg"
+		echo "preseed_partman_recipe_${sngdiskrecipe}raid_${spicelevel}.cfg"
+		logger -t sng "CHOSE preseed_partman_recipe_${sngdiskrecipe}raid_${spicelevel}.cfg"
 	fi
 else
 	echo "preseed_partman_nonraid.cfg"
@@ -78,27 +83,30 @@ else
 	elif [ "$dtype" = "x" ]; then
 		echo "preseed_partman_nonraid_disk_xv.cfg"
 		logger -t sng "CHOSE preseed_partman_nonraid_disk_xv.cfg"
+	elif [ "$dtype" = "n" ]; then
+		echo "preseed_partman_nonraid_disk_nvme.cfg"
+		logger -t sng "CHOSE preseed_partman_nonraid_disk_nvme.cfg"
 	else
 		echo "preseed_partman_nonraid_disk_s.cfg"
 		logger -t sng "CHOSE preseed_partman_nonraid_disk_s.cfg"
 	fi
         if [ "$spicelevel" = "int" ]; then
-                disk_part=$(list-devices disk | grep -e 'da$' | cut -f3 -d/)
+                disk_part=$(list-devices disk | grep -e 'da$' -e 'nvme[0-9]n[0-9]$' | cut -f3 -d/)
                 disk_size=$(awk '{print $1 * 512/ 1024/ 1024/ 1024 }' /sys/block/${disk_part}/size)
 		        result=$(eval "awk 'BEGIN {
           		       if ($disk_size <= 120) print 1;
                 	       else print 2;
                 	       }'")
         	if [ "$result" -eq 1 ] || [ "$disk_part" = "" ]; then
-                	echo "preseed_partman_recipe_nonraid_${spicelevel}_120.cfg"
-                	logger -t sng "CHOSE preseed_partman_recipe_nonraid_${spicelevel}_120.cfg"
+                	echo "preseed_partman_recipe_${sngdiskrecipe}nonraid_${spicelevel}_120.cfg"
+                	logger -t sng "CHOSE preseed_partman_recipe_${sngdiskrecipe}nonraid_${spicelevel}_120.cfg"
         	else
-                	echo "preseed_partman_recipe_nonraid_${spicelevel}_250.cfg"
-                	logger -t sng "CHOSE preseed_partman_recipe_nonraid_${spicelevel}_250.cfg"
+                	echo "preseed_partman_recipe_${sngdiskrecipe}nonraid_${spicelevel}_250.cfg"
+                	logger -t sng "CHOSE preseed_partman_recipe_${sngdiskrecipe}nonraid_${spicelevel}_250.cfg"
         	fi
 	else
-		echo "preseed_partman_recipe_nonraid_${spicelevel}.cfg"
-		logger -t sng "CHOSE preseed_partman_recipe_nonraid_${spicelevel}.cfg"
+		echo "preseed_partman_recipe_${sngdiskrecipe}nonraid_${spicelevel}.cfg"
+		logger -t sng "CHOSE preseed_partman_recipe_${sngdiskrecipe}nonraid_${spicelevel}.cfg"
 	fi
 fi
 	


### PR DESCRIPTION
* Support for single NVME drives (but not RAID or combinations with SATA drives). Resolves #26
* New SLAB disk recipe in bootloader to make only boot, root and swap partitions. Resolves #29
* Menu re-org for spice levels. Resolves #36
* Isolated menu help items into new Help submenu. Resolves #18
* More warnings about overwriting large USB drives. Addresses #25
* Moved Rescue boot modes to new Troubleshooting submenu.
* Adds Tango GRUB tune in more places.
* Friendlier welcome messages for newcomers.
* Improved hotkeys.